### PR TITLE
Lint 규칙상 불필요한 경우에도 dependencies 모듈 사용이 강제되는 문제 해결

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,4 +1,3 @@
-
 export default {
   extends: ["@commitlint/config-conventional"],
 };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@
 import pluginJs from "@eslint/js";
 import prettierConfig from "eslint-config-prettier";
 import prettierPluginRecommended from "eslint-plugin-prettier/recommended";
-import tseslint from "@typescript-eslint/eslint-plugin";
+import tseslint from "typescript-eslint";
 
 /** @see https://www.raulmelo.me/en/blog/migration-eslint-to-flat-config */
 import { FlatCompat } from "@eslint/eslintrc";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 import pluginJs from "@eslint/js";
-// eslint-disable-next-line import/no-unresolved
-import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
 import prettierPluginRecommended from "eslint-plugin-prettier/recommended";
+import tseslint from "@typescript-eslint/eslint-plugin";
 
 /** @see https://www.raulmelo.me/en/blog/migration-eslint-to-flat-config */
 import { FlatCompat } from "@eslint/eslintrc";
@@ -20,12 +19,25 @@ const compat = new FlatCompat({
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
-  {
-    ignores: ["*.config.js"]
-  },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   ...compat.extends("airbnb-base"),
   prettierConfig,
   prettierPluginRecommended,
+  {
+    rules: {
+      "import/no-extraneous-dependencies": [
+        "warn",
+        {
+          devDependencies: [
+            "**/*.config.{mts,ts,mjs,js}",
+            "**/storybook/**",
+            "**/stories/**",
+            "**/*.stories.{ts,tsx,js,jsx}",
+            "**/*.{spec,test},{ts,tsx,js,jsx}",
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,7 +34,7 @@ export default [
             "**/storybook/**",
             "**/stories/**",
             "**/*.stories.{ts,tsx,js,jsx}",
-            "**/*.{spec,test},{ts,tsx,js,jsx}",
+            "**/*.{spec,test}.{ts,tsx,js,jsx}",
           ],
         },
       ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": "true",
   "scripts": {
-    "lint": "eslint",
+    "lint": "eslint --filter \"frontend,backend\" lint",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "husky"
   },
@@ -20,15 +20,14 @@
     "lint-staged": "^15.2.10",
     "prettier": "3.3.3",
     "typescript": "^5.6.3",
-    "typescript-eslint": "^8.13.0"
-  },
-  "dependencies": {
+    "typescript-eslint": "^8.13.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.14.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1"
   },
+  "dependencies": {},
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --cache --fix",


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

모든 파일들에서 사용되는 모듈의 `dependencies` 사용이 강제되던 문제가 있던 문제를 해결했어요.

## ✅ 작업 내용

config 파일이나 storybook, test 파일과 같은 dev 환경에서 사용되는 파일에 대해서는 devDependencies를 허용하도록 `import/no-extraneous-dependencies` 룰을 수정했어요.

## 🏷️ 관련 이슈

- #74 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

config 파일에 대해서는 다음과 같이 devDependencies를 추가할 수 있습니다.

<img width="321" alt="스크린샷 2024-11-06 오전 10 54 33" src="https://github.com/user-attachments/assets/c2bc9ba0-727c-41a9-8bb0-daf6c3e9b79e">

나머지 파일에 대해서는 다음과 같이 devDependencies를 사용하면 경고가 발생합니다.

<img width="761" alt="스크린샷 2024-11-06 오전 10 51 25" src="https://github.com/user-attachments/assets/32cf3b13-8516-416e-82e3-20e77198278e">

<details>
<summary>나머지의 경우</summary>
<img width="355" alt="스크린샷 2024-11-06 오후 12 08 50" src="https://github.com/user-attachments/assets/f367298a-8e7d-49ad-a4f8-236a9d16847c">
<img width="323" alt="스크린샷 2024-11-06 오후 12 08 58" src="https://github.com/user-attachments/assets/f5bd9b28-0338-4c4e-823f-adacf3bf34ef">
<img width="407" alt="스크린샷 2024-11-06 오후 12 10 13" src="https://github.com/user-attachments/assets/049b25f3-1045-46f6-a0bb-0c864b1a1583">
<img width="386" alt="스크린샷 2024-11-06 오후 12 10 19" src="https://github.com/user-attachments/assets/8ce08b07-561f-42f6-851b-3abf6d545fe6">
<img width="354" alt="스크린샷 2024-11-06 오후 12 10 28" src="https://github.com/user-attachments/assets/17f9fdd9-dff0-4724-87ee-aaec34ff957f">
<img width="358" alt="스크린샷 2024-11-06 오후 12 10 52" src="https://github.com/user-attachments/assets/50b74fc9-25c8-47fc-9e83-e1e64e646436">

</details>

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)