### PR TITLE
블루/그린 전략으로 배포가 이루어질 수 있는 환경 설정 (프론트엔드 ci/cd 작업, 블루/그린 전략 고려 제외)

### DIFF
--- a/.github/workflows/FRONTEND_DEPLOY.yml
+++ b/.github/workflows/FRONTEND_DEPLOY.yml
@@ -114,16 +114,6 @@ jobs:
               }
             });
             
-            // 커밋에 배포 결과 코멘트 작성
-            await github.rest.repos.createCommitComment({
-              owner: context.repo.owner,
-              repo: context.repo.name,
-              commit_sha: context.sha,
-              body: finalOutcome === 'success'
-                ? '🎉 프론트엔드(+ shared package)가 성공적으로 배포되었습니다!'
-                : `❌ 배포에 실패했습니다. ${sharedOutcome === 'failure' ? 'shared package build' : 'frontend deploy'}의 단계를 살펴보세요.`
-            });
-
             // 실패 시 워크플로우를 실패 상태로 만듦
             if (finalOutcome === 'failure') {
               core.setFailed('Deployment process failed');

--- a/.github/workflows/FRONTEND_DEPLOY.yml
+++ b/.github/workflows/FRONTEND_DEPLOY.yml
@@ -1,0 +1,130 @@
+name: Frontend Deploy
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/frontend/**'
+      - 'packages/shared/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.4.0
+      
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '22.9.0'
+          cache: 'pnpm'
+      
+      - name: Install dependencies
+        run: pnpm install
+
+      # shared 패키지 먼저 빌드
+      - name: Build shared package
+        id: build-shared
+        working-directory: packages/shared
+        run: pnpm build
+        continue-on-error: true
+
+      # 🚨 shared 빌드 실패 시 전체 프로세스 중단
+      - name: Check shared build
+        if: steps.build-shared.outcome == 'failure'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed('Shared package build failed');
+      
+      # frontend 빌드 및 배포
+      - name: Build and Deploy Frontend
+        id: deploy
+        if: steps.build-shared.outcome == 'success'
+        working-directory: packages/frontend
+        env:
+          NCP_ACCESS_KEY: ${{ secrets.NCP_ACCESS_KEY }}
+          NCP_SECRET_KEY: ${{ secrets.NCP_SECRET_KEY }}
+          NCP_BUCKET_NAME: ${{ secrets.NCP_BUCKET_NAME }}
+        run: |
+          echo "🏗️ Building frontend..."
+          pnpm build
+          
+          echo "📦 Installing NCP CLI..."
+          pip install ncli
+          
+          echo "🚀 Deploying to NCP Object Storage..."
+          ncli objectstorage cp -r ./dist/* s3://$NCP_BUCKET_NAME/
+        continue-on-error: true
+
+      # 배포 결과 처리
+      - name: Process Deploy Result
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const sharedOutcome = '${{ steps.build-shared.outcome }}';
+            const deployOutcome = '${{ steps.deploy.outcome }}';
+            const finalOutcome = sharedOutcome === 'success' && deployOutcome === 'success' ? 'success' : 'failure';
+            
+            // GitHub Checks로 배포 상태 보고
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              name: 'Frontend Deploy',
+              head_sha: context.sha,
+              status: 'completed',
+              conclusion: finalOutcome === 'success' ? 'success' : 'failure',
+              output: {
+                title: finalOutcome === 'success' 
+                  ? '🚀 Frontend Deploy Successful' 
+                  : '❌ Frontend Deploy Failed',
+                summary: finalOutcome === 'success'
+                  ? [
+                      '## ✅ Deploy Status: Success',
+                      '',
+                      '### Build & Deploy Information:',
+                      '- **Time**: ' + new Date().toISOString(),
+                      '- **Environment**: Production',
+                      '- **Packages Built**: shared, frontend',
+                      '- **Target**: NCP Object Storage',
+                      '',
+                      '🎉 Successfully deployed to production!'
+                    ].join('\n')
+                  : [
+                      '## ❌ Deploy Status: Failed',
+                      '',
+                      '### Error 정보:',
+                      '- **Time**: ' + new Date().toISOString(),
+                      '- **Failed Step**: ' + (sharedOutcome === 'failure' ? 'Shared Package Build' : 'Frontend Deploy'),
+                      '',
+                      '### Error 부가정보:',
+                      sharedOutcome === 'failure' 
+                        ? '- Shared package build failed. Check the shared package build logs.'
+                        : '- Frontend deployment failed. Check the deployment logs.',
+                      '',
+                    ].join('\n')
+              }
+            });
+            
+            // 커밋에 배포 결과 코멘트 작성
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              commit_sha: context.sha,
+              body: finalOutcome === 'success'
+                ? '🎉 프론트엔드(+ shared package)가 성공적으로 배포되었습니다!'
+                : `❌ 배포에 실패했습니다. ${sharedOutcome === 'failure' ? 'shared package build' : 'frontend deploy'}의 단계를 살펴보세요.`
+            });
+
+            // 실패 시 워크플로우를 실패 상태로 만듦
+            if (finalOutcome === 'failure') {
+              core.setFailed('Deployment process failed');
+            }

--- a/.github/workflows/FRONTEND_PR_CHECK.yml
+++ b/.github/workflows/FRONTEND_PR_CHECK.yml
@@ -1,0 +1,91 @@
+name: Frontend PR Check
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'packages/frontend/**'
+      - 'packages/shared/**'
+
+jobs:
+  build-check:
+    if: contains(github.head_ref, 'dev-fe')
+    runs-on: ubuntu-latest
+    
+    # Checks API 권한
+    permissions:
+      checks: write
+      
+    steps:
+      - uses: actions/checkout@v3
+      
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.4.0
+      
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '22.9.0'
+          cache: 'pnpm'
+      
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Build frontend
+        id: build
+        working-directory: packages/frontend
+        run: pnpm build
+        continue-on-error: true
+
+      - name: Process Build Result
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const buildOutcome = '${{ steps.build.outcome }}';
+            
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              name: 'Frontend Build',
+              head_sha: context.sha,
+              status: 'completed',
+              conclusion: buildOutcome === 'success' ? 'success' : 'failure',
+              output: {
+                title: buildOutcome === 'success' 
+                  ? '🎉 Frontend Build Successful' 
+                  : '❌ Frontend Build Failed',
+                
+                summary: buildOutcome === 'success'
+                  ? [
+                      '## ✅ Build Status: Success',
+                      '',
+                      '### Build Information:',
+                      '- **Build Time**: ' + new Date().toISOString(),
+                      '- **Branch**: ' + context.ref,
+                      '',
+                      '✨ Ready to be reviewed!'
+                    ].join('\n')
+                  : [
+                      '## ❌ Build Status: Failed',
+                      '',
+                      '### Error Information:',
+                      '- **Build Time**: ' + new Date().toISOString(),
+                      '- **Branch**: ' + context.ref,
+                      '',
+                      '### Next Steps:',
+                      '1. Check the build logs for detailed error messages',
+                      '2. Fix the identified issues',
+                      '3. Push your changes to trigger a new build',
+                      '',
+                      '> Need help? Contact the frontend team.'
+                    ].join('\n'),
+                
+                text: buildOutcome === 'success'
+                  ? '자세한 빌드 로그는 Actions 탭에서 확인하실 수 있습니다.'
+                  : '빌드 실패 원인을 확인하시려면 위의 "Details"를 클릭하세요.'
+              }
+            });
+
+            if (buildOutcome === 'failure') {
+              core.setFailed('Frontend build failed');
+            }


### PR DESCRIPTION
## ✏️ 한 줄 설명

프론트엔드의 CI/CD를 위한 github action 스크립트를 작성했습니다.

## ✅ 작업 내용

- main을 향한 PR에 대해 빌드 검증을 하는 `FRONTEND_PR_CHECK.yml` 작성
( frontend와 shared 디렉토리 변경에 대해서 진행. 빌드 결과를 checks를 통해 기록 )

- main에 push될 때 빌드 검증 후 배포하는 `FRONTEND_DEPLOY.yml` 작성
( 배포 결과를 checks를 통해 기록 )

## 🏷️ 관련 이슈
- https://github.com/boostcampwm-2024/web29-honeyflow/issues/24

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

`on:` 설정 부분에서 **액션을 트리거 시키는 조건 위주**로 검토 부탁드립니다 :) 