### PR TITLE
pr 리뷰 알림 발동 조건 변경

### DIFF
--- a/.github/workflows/REVIEW_REQUEST_ALERT.yml
+++ b/.github/workflows/REVIEW_REQUEST_ALERT.yml
@@ -1,9 +1,9 @@
 name: BeeBot
 on:
   pull_request:
-    types: [review_requested]
+    types: [review_request_removed]
 jobs:
-  specific_review_requested:
+  notify_automatically_assigned_review_request:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

- codeowners를 통한 리뷰어 자동 등록이 review request를 3번 발동시키는 현상때문에 알람이 여러번 전송되는 문제 해결을 위함

## ✅ 작업 내용
- [x] github action 발동 조건 변경

## 🏷️ 관련 이슈
- #81 

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

예상치 못하게 슬랙봇을 잘 동작시키기가 어렵네요. ㅎㅎ 커밋 이력을 더 더럽히지 않기 위해서 앞으로는 main 브랜치 수정이 아닌 PR을 꼭 올리도록 하겠습니다.