### PR TITLE
Head Node UI 구현

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,9 +18,11 @@
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "konva": "^9.3.16",
     "lucide-react": "^0.454.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-konva": "^18.2.10",
     "react-router-dom": "^6.28.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -1,42 +1,13 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+}
+
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  width: 100%;
+  min-height: 100%;
+  height: 100%;
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,12 +1,14 @@
 import "./App.css";
 import { Routes, Route, BrowserRouter } from "react-router-dom";
 import Home from "./pages/Home.tsx";
+import SpacePage from "./pages/Space.tsx";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/space/:entrySpaceId" element={<SpacePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/packages/frontend/src/components/space/SpaceNode.stories.tsx
+++ b/packages/frontend/src/components/space/SpaceNode.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Layer, Stage } from "react-konva";
 
 import type { Meta, StoryObj } from "@storybook/react";
@@ -8,10 +9,26 @@ export default {
   component: SpaceNode,
   tags: ["autodocs"],
   decorators: [
-    (Story) => {
-      // TODO: Konva를 위한 decorator 별도로 분리 작성 必
-      const width = 1000;
-      const height = 1000;
+    (Story, { canvasElement }) => {
+      // TODO: Konva Node를 위한 decorator 별도로 분리 必
+      const [size, setSize] = useState(() => ({
+        width: Math.max(canvasElement.clientWidth, 256),
+        height: Math.max(canvasElement.clientHeight, 256),
+      }));
+
+      const { width, height } = size;
+
+      useEffect(() => {
+        const observer = new ResizeObserver((entries) => {
+          entries.forEach((entry) => {
+            const { width, height } = entry.contentRect;
+            setSize({ width, height });
+          });
+        });
+
+        observer.observe(canvasElement);
+        return () => observer.unobserve(canvasElement);
+      }, [canvasElement]);
 
       return (
         <Stage width={width} height={height} draggable>

--- a/packages/frontend/src/components/space/SpaceNode.stories.tsx
+++ b/packages/frontend/src/components/space/SpaceNode.stories.tsx
@@ -1,0 +1,33 @@
+import { Layer, Stage } from "react-konva";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+import SpaceNode from "./SpaceNode.tsx";
+
+export default {
+  component: SpaceNode,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => {
+      // TODO: Konva를 위한 decorator 별도로 분리 작성 必
+      const width = 1000;
+      const height = 1000;
+
+      return (
+        <Stage width={width} height={height} draggable>
+          <Layer offsetX={-width / 2} offsetY={-height / 2}>
+            <Story />
+          </Layer>
+        </Stage>
+      );
+    },
+  ],
+} satisfies Meta<typeof SpaceNode>;
+
+export const Normal: StoryObj = {
+  args: {
+    label: "HelloWorld",
+    x: 0,
+    y: 0,
+  },
+};

--- a/packages/frontend/src/components/space/SpaceNode.tsx
+++ b/packages/frontend/src/components/space/SpaceNode.tsx
@@ -22,7 +22,7 @@ function TextWithCenteredAnchor(props: Konva.TextConfig) {
     if (props.offsetY === undefined) {
       setOffsetY(ref.current.height() / 2);
     }
-  }, [props.offset, props.offsetX, props.offsetY]);
+  }, [props]);
 
   return <Text ref={ref} offsetX={offsetX} offsetY={offsetY} {...props} />;
 }

--- a/packages/frontend/src/components/space/SpaceNode.tsx
+++ b/packages/frontend/src/components/space/SpaceNode.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, useRef } from "react";
+import { Circle, Group, Text } from "react-konva";
+
+import type Konva from "konva";
+
+export interface SpaceNodeProps {
+  label?: string;
+  x: number;
+  y: number;
+}
+const SpaceNode = forwardRef<Konva.Group, SpaceNodeProps>(
+  ({ label, x, y }, ref) => {
+    const fillColor = "royalblue";
+
+    const textRef = useRef<Konva.Text>(null);
+    const textOffset = textRef.current
+      ? { x: textRef.current.width() / 2, y: textRef.current.height() / 2 }
+      : undefined;
+
+    return (
+      <Group ref={ref} x={x} y={y}>
+        <Circle x={0} y={0} radius={48} fill={fillColor} />
+        <Text
+          ref={textRef}
+          x={0}
+          y={0}
+          text={label}
+          fill="white"
+          offset={textOffset}
+        />
+      </Group>
+    );
+  },
+);
+SpaceNode.displayName = "SpaceNode";
+
+export default SpaceNode;

--- a/packages/frontend/src/components/space/SpaceNode.tsx
+++ b/packages/frontend/src/components/space/SpaceNode.tsx
@@ -1,7 +1,31 @@
-import { forwardRef, useRef } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import { Circle, Group, Text } from "react-konva";
 
-import type Konva from "konva";
+import Konva from "konva";
+
+// FIXME: 이런 동작이 많이 필요할 것 같아 별도의 파일로 분리할 것
+function TextWithCenteredAnchor(props: Konva.TextConfig) {
+  const ref = useRef<Konva.Text>(null);
+
+  const [offsetX, setOffsetX] = useState<number | undefined>(undefined);
+  const [offsetY, setOffsetY] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!ref.current || props.offset !== undefined) {
+      return;
+    }
+
+    if (props.offsetX === undefined) {
+      setOffsetX(ref.current.width() / 2);
+    }
+
+    if (props.offsetY === undefined) {
+      setOffsetY(ref.current.height() / 2);
+    }
+  }, [props.offset, props.offsetX, props.offsetY]);
+
+  return <Text ref={ref} offsetX={offsetX} offsetY={offsetY} {...props} />;
+}
 
 export interface SpaceNodeProps {
   label?: string;
@@ -10,24 +34,14 @@ export interface SpaceNodeProps {
 }
 const SpaceNode = forwardRef<Konva.Group, SpaceNodeProps>(
   ({ label, x, y }, ref) => {
+    // TODO: 색상에 대해 정하기, 크기에 대해 정하기
     const fillColor = "royalblue";
-
-    const textRef = useRef<Konva.Text>(null);
-    const textOffset = textRef.current
-      ? { x: textRef.current.width() / 2, y: textRef.current.height() / 2 }
-      : undefined;
+    const textColor = "white";
 
     return (
       <Group ref={ref} x={x} y={y}>
         <Circle x={0} y={0} radius={48} fill={fillColor} />
-        <Text
-          ref={textRef}
-          x={0}
-          y={0}
-          text={label}
-          fill="white"
-          offset={textOffset}
-        />
+        <TextWithCenteredAnchor x={0} y={0} text={label} fill={textColor} />
       </Group>
     );
   },

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import { Layer, Stage } from "react-konva";
+
+import SpaceNode from "./SpaceNode.tsx";
+
+interface SpaceViewProps {
+  autofitTo?: Element | React.RefObject<Element>;
+}
+
+export default function SpaceView({ autofitTo }: SpaceViewProps) {
+  const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    if (!autofitTo) {
+      return undefined;
+    }
+
+    const containerRef =
+      "current" in autofitTo ? autofitTo : { current: autofitTo };
+
+    function resizeStage() {
+      const container = containerRef.current;
+
+      if (!container) {
+        return;
+      }
+
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+
+      setStageSize({ width, height });
+    }
+
+    resizeStage();
+
+    window.addEventListener("resize", resizeStage);
+    return () => {
+      window.removeEventListener("resize", resizeStage);
+    };
+  }, [autofitTo]);
+
+  return (
+    <Stage width={stageSize.width} height={stageSize.height} draggable>
+      <Layer offsetX={-stageSize.width / 2} offsetY={-stageSize.height / 2}>
+        <SpaceNode label="HEAD NODE" x={0} y={0} />
+      </Layer>
+    </Stage>
+  );
+}

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -1,0 +1,28 @@
+import { useRef } from "react";
+import { useParams } from "react-router-dom";
+
+import SpaceView from "@/components/space/SpaceView.tsx";
+
+interface SpacePageParams extends Record<string, string | undefined> {
+  entrySpaceId?: string;
+}
+
+export default function SpacePage() {
+  const { entrySpaceId } = useParams<SpacePageParams>();
+
+  if (!entrySpaceId) {
+    throw new Error("");
+  }
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div
+      className="text-sm"
+      style={{ width: "100%", height: "100%" }}
+      ref={containerRef}
+    >
+      <SpaceView autofitTo={containerRef} />
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 9.14.0(jiti@1.21.6)
       eslint-config-airbnb-base:
         specifier: ^15.0.0
-        version: 15.0.0(eslint-plugin-import@2.31.0(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+        version: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.14.0(jiti@1.21.6))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(eslint@9.14.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6))
       eslint-plugin-prettier:
         specifier: ^5.2.1
         version: 5.2.1(eslint-config-prettier@9.1.0(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))(prettier@3.3.3)
@@ -70,6 +70,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      konva:
+        specifier: ^9.3.16
+        version: 9.3.16
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@18.3.1)
@@ -79,6 +82,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-konva:
+        specifier: ^18.2.10
+        version: 18.2.10(konva@9.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.28.0
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1211,6 +1217,9 @@ packages:
   '@types/react-dom@18.3.1':
     resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
 
+  '@types/react-reconciler@0.28.8':
+    resolution: {integrity: sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==}
+
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
@@ -2291,6 +2300,11 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  its-fine@1.2.5:
+    resolution: {integrity: sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==}
+    peerDependencies:
+      react: '>=18.0'
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -2355,6 +2369,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  konva@9.3.16:
+    resolution: {integrity: sha512-qa47cefGDDHzkToGRGDsy24f/Njrz7EHP56jQ8mlDcjAPO7vkfTDeoBDIfmF7PZtpfzDdooafQmEUJMDU2F7FQ==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2838,6 +2855,19 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-konva@18.2.10:
+    resolution: {integrity: sha512-ohcX1BJINL43m4ynjZ24MxFI1syjBdrXhqVxYVDw2rKgr3yuS0x/6m1Y2Z4sl4T/gKhfreBx8KHisd0XC6OT1g==}
+    peerDependencies:
+      konva: ^8.0.1 || ^7.2.5 || ^9.0.0
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  react-reconciler@0.29.2:
+    resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^18.3.1
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -4570,6 +4600,10 @@ snapshots:
     dependencies:
       '@types/react': 18.3.12
 
+  '@types/react-reconciler@0.28.8':
+    dependencies:
+      '@types/react': 18.3.12
+
   '@types/react@18.3.12':
     dependencies:
       '@types/prop-types': 15.7.13
@@ -5247,11 +5281,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 9.14.0(jiti@1.21.6)
-      eslint-plugin-import: 2.31.0(eslint@9.14.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6))
       object.assign: 4.1.5
       object.entries: 1.1.8
       semver: 6.3.1
@@ -5268,16 +5302,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.14.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.14.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.14.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(eslint@9.14.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5288,7 +5323,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.14.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.14.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.14.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -5299,6 +5334,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.13.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -5763,6 +5800,11 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  its-fine@1.2.5(react@18.3.1):
+    dependencies:
+      '@types/react-reconciler': 0.28.8
+      react: 18.3.1
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -5812,6 +5854,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  konva@9.3.16: {}
 
   levn@0.4.1:
     dependencies:
@@ -6210,6 +6254,22 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@17.0.2: {}
+
+  react-konva@18.2.10(konva@9.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@types/react-reconciler': 0.28.8
+      its-fine: 1.2.5(react@18.3.1)
+      konva: 9.3.16
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-reconciler: 0.29.2(react@18.3.1)
+      scheduler: 0.23.2
+
+  react-reconciler@0.29.2(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
 
   react-refresh@0.14.2: {}
 


### PR DESCRIPTION
(rebase해서 올렸습니다)

## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

Space 페이지를 생성하고, 중앙 노드가 렌더링되도록 했어요.

## ✅ 작업 내용

- Space 페이지를 추가했어요.
- Space 렌더링을 위한 Konva 캔버스를 추가했어요.
- Space 중앙 (0, 0)에 중앙 노드가 배치되는 걸 구현했어요.
- Space 노드에 대한 Storybook을 작성하고, 이를 위해 필요한 Konva 캔버스도 데코레이터로 나타냈어요.

## 🏷️ 관련 이슈

- #28

close #28  

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

![화면 기록 2024-11-07 오후 8 24 40](https://github.com/user-attachments/assets/11eb8ebb-35ed-4ab1-a5da-a3eda0f239d3)

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/23021293-9644-4458-9b85-57e1e234fee5">

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

아직 확장성 있게 컴포넌트를 설계하기엔 데이터 구조랑이 명확해지기 전까지는 어려울 것 같아, 개략적인 구조만 잡았습니다.
