### PR TITLE
팔레트 메뉴 UI 구현

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,8 +1,9 @@
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+
 import "./App.css";
-import { Routes, Route, BrowserRouter } from "react-router-dom";
+import PaletteMenu from "./components/space/PaletteMenu.tsx";
 import Home from "./pages/Home.tsx";
 import SpacePage from "./pages/Space.tsx";
-import PaletteMenu from "./components/space/PaletteMenu.tsx";
 
 function App() {
   return (
@@ -10,7 +11,6 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/space/:entrySpaceId" element={<SpacePage />} />
-        <Route path="/palette" element={<PaletteMenu itemTypes={["note", "image", "link"]} />} />
       </Routes>
     </BrowserRouter>
   );

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import "./App.css";
-import PaletteMenu from "./components/space/PaletteMenu.tsx";
 import Home from "./pages/Home.tsx";
 import SpacePage from "./pages/Space.tsx";
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import "./App.css";
 import { Routes, Route, BrowserRouter } from "react-router-dom";
 import Home from "./pages/Home.tsx";
 import SpacePage from "./pages/Space.tsx";
+import PaletteMenu from "./components/space/PaletteMenu.tsx";
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/space/:entrySpaceId" element={<SpacePage />} />
+        <Route path="/palette" element={<PaletteMenu itemTypes={["note", "image", "link"]} />} />
       </Routes>
     </BrowserRouter>
   );

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -66,7 +66,7 @@ function getPositionByIndex(index: number): Position {
 }
 
 export default function PaletteMenu({ items }: PaletteMenuProps) {
-  if (process.env.NODE_ENV === "development" && items.length > MAX_ITEMS) {
+  if (import.meta.env.MODE === "development" && items.length > MAX_ITEMS) {
     throw new Error(
       `팔레트 메뉴는 ${MAX_ITEMS}개의 옵션만 표시할 수 있습니다.`,
     );

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -1,0 +1,62 @@
+import { X, Image, Link, NotebookPen } from 'lucide-react';
+
+type PaletteButtonType = 'note' | 'image' | 'link' | 'close';   
+type PaletteButtonProps = {
+    variant: PaletteButtonType;
+}
+
+function PaletteButton({ 
+    variant,
+}: PaletteButtonProps ) {
+
+    const buttonConfig = {
+        note: {
+          icon: NotebookPen,
+          color: 'fill-yellow-300',
+          // TODO: 이후 추가될 것을 고려하여 작성
+          //   handler: async () => {
+          //   }
+        },
+        image: {
+          icon: Image,
+          color: 'fill-yellow-400',
+        },
+        link: {
+          icon: Link,
+          color: 'fill-yellow-500',
+        },
+        close: {
+          icon: X,
+          color: 'fill-yellow-200',
+        }
+      } as const;
+
+    const config = buttonConfig[variant]
+    const Icon = config.icon;  
+    
+    return (
+        <button className="relative w-20 h-20 transition-transform hover:scale-110">
+            <svg viewBox="0 0 100 100">
+                <polygon points="50 0, 93.3 25, 93.3 75, 50 100, 6.7 75, 6.7 25" className={config.color} />
+            </svg>
+            <div className="absolute inset-0 flex items-center justify-center">
+                <Icon className="w-6 h-6" />
+            </div>
+        </button>
+    );
+}
+
+
+export default function PaletteMenu() {
+    return (
+        <div>
+            <PaletteButton variant='note'/>
+            <PaletteButton variant='close'/>
+            <PaletteButton variant='image'/>
+            <PaletteButton variant='link'/>
+            <PaletteButton variant='image'/>
+            <PaletteButton variant='note'/>
+            <PaletteButton variant='link'/>
+        </div>
+    );
+}

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -1,101 +1,101 @@
-import { X, Image, Link, NotebookPen } from 'lucide-react';
+import { Image, Link, LucideIcon, NotebookPen, X } from "lucide-react";
 
-type PaletteButtonType = 'note' | 'image' | 'link' | 'close';   
-type Position = { top: number; left: number;}
+type PaletteButtonType = "note" | "image" | "link" | "close";
+type Position = { top: number; left: number };
 
 type PaletteButtonProps = {
-    variant: PaletteButtonType;
-    position?: Position;
-    buttonSize: number;
+  variant: PaletteButtonType;
+  position: Position;
+};
+
+const buttonConfig: Record<
+  PaletteButtonType,
+  { icon: LucideIcon; color: string }
+> = {
+  note: { icon: NotebookPen, color: "fill-yellow-300" },
+  image: { icon: Image, color: "fill-yellow-400" },
+  link: { icon: Link, color: "fill-yellow-500" },
+  close: { icon: X, color: "fill-yellow-200" },
+};
+
+const CONTAINER_SIZE = 160;
+const BUTTON_SIZE = 60;
+const RADIUS = 55;
+const MAX_ITEMS = 6;
+
+function PaletteButton({ variant, position }: PaletteButtonProps) {
+  const { icon: Icon, color } = buttonConfig[variant];
+
+  return (
+    <button
+      className="absolute transition-transform hover:scale-110"
+      style={{
+        top: position.top,
+        left: position.left,
+        width: BUTTON_SIZE,
+        height: BUTTON_SIZE,
+      }}
+    >
+      <svg viewBox="0 0 100 100">
+        <polygon
+          points="50 0, 93.3 25, 93.3 75, 50 100, 6.7 75, 6.7 25"
+          className={color}
+        />
+      </svg>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <Icon className="w-6 h-6" />
+      </div>
+    </button>
+  );
 }
-
-function PaletteButton({ 
-    variant,
-    position,
-    buttonSize,
-}: PaletteButtonProps ) {
-    const buttonConfig = {
-        note: {
-          icon: NotebookPen,
-          color: 'fill-yellow-300',
-          // TODO: 이후 추가될 것을 고려하여 작성
-          //   handler: async () => {
-          //   }
-        },
-        image: {
-          icon: Image,
-          color: 'fill-yellow-400',
-        },
-        link: {
-          icon: Link,
-          color: 'fill-yellow-500',
-        },
-        close: {
-          icon: X,
-          color: 'fill-yellow-200',
-        }
-      } as const;
-
-    const config = buttonConfig[variant]
-    const Icon = config.icon;  
-
-    return (
-        <button
-            className="absolute transition-transform hover:scale-110"
-            style={{ 
-                top: position?.top || undefined,
-                left: position?.left || undefined,
-                width: buttonSize,
-                height: buttonSize
-            }}
-        >
-            <svg viewBox="0 0 100 100">
-                <polygon points="50 0, 93.3 25, 93.3 75, 50 100, 6.7 75, 6.7 25" className={config.color} />
-            </svg>
-            <div className="absolute inset-0 flex items-center justify-center">
-                <Icon className="w-6 h-6" />
-            </div>
-        </button>
-    );
-}
-
 
 type PaletteMenuProps = {
-    itemTypes: PaletteButtonType[];
+  /** 팔레트 메뉴에 표시 옵션 (최대 6개) */
+  items: PaletteButtonType[];
+};
+
+function getPositionByIndex(index: number): Position {
+  const centerPoint = CONTAINER_SIZE / 2;
+  const angle = index * (360 / MAX_ITEMS) * (Math.PI / 180);
+  const offset = centerPoint - BUTTON_SIZE / 2;
+
+  return {
+    top: offset + RADIUS * Math.sin(angle),
+    left: offset + RADIUS * Math.cos(angle),
+  };
 }
 
-export default function PaletteMenu({
-    itemTypes
-}: PaletteMenuProps) {
-
-    const layoutConfig = { 
-        radius: 60,
-        centerPoint: 80,
-        containerSize: 160,
-        buttonSize: 60
-    } as const;
-
-    const getPositionByIndex = (index: number): Position => {
-        const angle = (index * 60) * (Math.PI / 180); 
-        
-        return {
-            top: layoutConfig['centerPoint'] - layoutConfig['buttonSize']/2 + (layoutConfig['radius'] * Math.sin(angle)),
-            left: layoutConfig['centerPoint'] - layoutConfig['buttonSize']/2 + (layoutConfig['radius'] * Math.cos(angle))
-        };
-    };
-
-    return (
-        <div className='relative bg-red-600 w-40 h-40'>
-            <PaletteButton variant='close' position={{ top: layoutConfig['containerSize']/2-layoutConfig['buttonSize'] / 2, left: layoutConfig['containerSize']/2 -layoutConfig['buttonSize'] / 2
-              }} buttonSize={layoutConfig['buttonSize']}/>
-            {itemTypes.map((variant, index) => (
-                <PaletteButton 
-                    key={index}
-                    variant={variant}
-                    position={getPositionByIndex(index)}
-                    buttonSize={layoutConfig['buttonSize']}
-                />
-            ))}
-        </div>
+export default function PaletteMenu({ items }: PaletteMenuProps) {
+  if (process.env.NODE_ENV === "development" && items.length > MAX_ITEMS) {
+    throw new Error(
+      `팔레트 메뉴는 ${MAX_ITEMS}개의 옵션만 표시할 수 있습니다.`,
     );
+  }
+
+  const centerOffset = CONTAINER_SIZE / 2 - BUTTON_SIZE / 2;
+
+  return (
+    <div
+      className="relative"
+      style={{
+        width: CONTAINER_SIZE,
+        height: CONTAINER_SIZE,
+      }}
+    >
+      <PaletteButton
+        variant="close"
+        position={{
+          top: centerOffset,
+          left: centerOffset,
+        }}
+      />
+      {items.slice(0, MAX_ITEMS).map((variant, index) => (
+        <PaletteButton
+          key={`${variant}-${index}`}
+          variant={variant}
+          position={getPositionByIndex(index)}
+        />
+      ))}
+    </div>
+  );
 }

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -1,14 +1,19 @@
 import { X, Image, Link, NotebookPen } from 'lucide-react';
 
 type PaletteButtonType = 'note' | 'image' | 'link' | 'close';   
+type Position = { top: number; left: number;}
+
 type PaletteButtonProps = {
     variant: PaletteButtonType;
+    position?: Position;
+    buttonSize: number;
 }
 
 function PaletteButton({ 
     variant,
+    position,
+    buttonSize,
 }: PaletteButtonProps ) {
-
     const buttonConfig = {
         note: {
           icon: NotebookPen,
@@ -33,9 +38,17 @@ function PaletteButton({
 
     const config = buttonConfig[variant]
     const Icon = config.icon;  
-    
+
     return (
-        <button className="relative w-20 h-20 transition-transform hover:scale-110">
+        <button
+            className="absolute transition-transform hover:scale-110"
+            style={{ 
+                top: position?.top || undefined,
+                left: position?.left || undefined,
+                width: buttonSize,
+                height: buttonSize
+            }}
+        >
             <svg viewBox="0 0 100 100">
                 <polygon points="50 0, 93.3 25, 93.3 75, 50 100, 6.7 75, 6.7 25" className={config.color} />
             </svg>
@@ -47,16 +60,42 @@ function PaletteButton({
 }
 
 
-export default function PaletteMenu() {
+type PaletteMenuProps = {
+    itemTypes: PaletteButtonType[];
+}
+
+export default function PaletteMenu({
+    itemTypes
+}: PaletteMenuProps) {
+
+    const layoutConfig = { 
+        radius: 60,
+        centerPoint: 80,
+        containerSize: 160,
+        buttonSize: 60
+    } as const;
+
+    const getPositionByIndex = (index: number): Position => {
+        const angle = (index * 60) * (Math.PI / 180); 
+        
+        return {
+            top: layoutConfig['centerPoint'] - layoutConfig['buttonSize']/2 + (layoutConfig['radius'] * Math.sin(angle)),
+            left: layoutConfig['centerPoint'] - layoutConfig['buttonSize']/2 + (layoutConfig['radius'] * Math.cos(angle))
+        };
+    };
+
     return (
-        <div>
-            <PaletteButton variant='note'/>
-            <PaletteButton variant='close'/>
-            <PaletteButton variant='image'/>
-            <PaletteButton variant='link'/>
-            <PaletteButton variant='image'/>
-            <PaletteButton variant='note'/>
-            <PaletteButton variant='link'/>
+        <div className='relative bg-red-600 w-40 h-40'>
+            <PaletteButton variant='close' position={{ top: layoutConfig['containerSize']/2-layoutConfig['buttonSize'] / 2, left: layoutConfig['containerSize']/2 -layoutConfig['buttonSize'] / 2
+              }} buttonSize={layoutConfig['buttonSize']}/>
+            {itemTypes.map((variant, index) => (
+                <PaletteButton 
+                    key={index}
+                    variant={variant}
+                    position={getPositionByIndex(index)}
+                    buttonSize={layoutConfig['buttonSize']}
+                />
+            ))}
         </div>
     );
 }

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
+import PaletteMenu from "@/components/space/PaletteMenu";
 
 type CreateSpaceButtonProps = {
   navigate: NavigateFunction;
@@ -95,6 +96,7 @@ export default function Home() {
           끈적끈적 꿀처럼 이루어지는 협업 지식 관리 툴 🍯
         </span>
       </div>
+      <PaletteMenu itemTypes={["note", "image", "link", "note", "link", "image"]} />
       <div className="flex flex-col gap-4">
         <CreateSpaceButton
           navigate={navigate}

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/components/ui/dialog.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
-import PaletteMenu from "@/components/space/PaletteMenu";
 
 type CreateSpaceButtonProps = {
   navigate: NavigateFunction;
@@ -96,7 +95,6 @@ export default function Home() {
           끈적끈적 꿀처럼 이루어지는 협업 지식 관리 툴 🍯
         </span>
       </div>
-      <PaletteMenu itemTypes={["note", "image", "link", "note", "link", "image"]} />
       <div className="flex flex-col gap-4">
         <CreateSpaceButton
           navigate={navigate}


### PR DESCRIPTION
## ✏️ 한 줄 설명

옵션 값을 받아 육각형으로 생성되는 팔레트 UI를 구현하였어요.


## ✅ 작업 내용
- [x] 팔레트 UI

## 🏷️ 관련 이슈
https://github.com/boostcampwm-2024/web29-honeyflow/issues/50

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.
![화면 기록 2024-11-13 오전 12 48 51](https://github.com/user-attachments/assets/c553a279-40a9-4b1c-8c10-b88e54f570b0)




## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

아래와 같이 메뉴에 표시할 옵션을 넘겨서 활용해요. (6개 미만이어도 차례대로 육각형 모양에 따른 위치에 표시돼요)
```jsx
<PaletteMenu items={ [ "note" , "image", "link" ] } /> 
```

6개를 초과하여 넘기면 에러가 발생하도록 했어요. 
<img width="640" alt="스크린샷 2024-11-13 오전 12 43 34" src="https://github.com/user-attachments/assets/ac4b6959-0ec4-4b36-bdce-0eee500b7682">

- 상수 처리를 너무 많이한 것 같은데, 가독성이 떨어지는 부분에 대해서 적극적으로 알려주세요
- 옵션마다 메뉴를 다르게 표시하는 형태인데, 이 다양성을 처리하는 방식에 대해 고민이에요
- 그 외에 TailWind 꿀팁...
