### PR TITLE
Edge 구현 및 노드 관련 더미 데이터 추가

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,7 +25,8 @@
     "react-konva": "^18.2.10",
     "react-router-dom": "^6.28.0",
     "tailwind-merge": "^2.5.4",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "shared": "workspace:*"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",

--- a/packages/frontend/src/components/Edge.tsx
+++ b/packages/frontend/src/components/Edge.tsx
@@ -2,42 +2,43 @@ import { useEffect, useState } from "react";
 import { Line } from "react-konva";
 
 import Konva from "konva";
+import type { Edge } from "shared/types";
 
-import type { Node } from "./mock";
+type EdgeProps = Edge & Konva.LineConfig;
 
-type EdgeProps = {
-  from: Node["id"];
-  to: Node["id"];
-  nodes: Node[];
-} & Konva.LineConfig;
+function calculateOffsets(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  radius: number,
+) {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const distance = Math.sqrt(dx * dx + dy * dy);
 
-export default function Edge({ from, to, nodes }: EdgeProps) {
+  const offsetX = (dx / distance) * radius;
+  const offsetY = (dy / distance) * radius;
+
+  return { offsetX, offsetY };
+}
+
+export default function Edge({ from, to, ...rest }: EdgeProps) {
   const [points, setPoints] = useState<number[]>([]);
   const RADIUS = 64;
 
   useEffect(() => {
-    const fromNode = nodes.find((node) => node.id === from);
-    const toNode = nodes.find((node) => node.id === to);
+    if (from && to) {
+      const { offsetX, offsetY } = calculateOffsets(from, to, RADIUS);
 
-    if (fromNode && toNode) {
-      // 두 노드 간의 방향 벡터를 계산
-      const dx = toNode.x - fromNode.x;
-      const dy = toNode.y - fromNode.y;
-      const distance = Math.sqrt(dx * dx + dy * dy);
-
-      // 방향 벡터를 정규화하여 반지름만큼 떨어진 점을 계산
-      const offsetX = (dx / distance) * RADIUS;
-      const offsetY = (dy / distance) * RADIUS;
-
-      // Line의 시작점과 끝점을 각각 노드 원의 경계로 조정
       setPoints([
-        fromNode.x + offsetX,
-        fromNode.y + offsetY,
-        toNode.x - offsetX,
-        toNode.y - offsetY,
+        from.x + offsetX,
+        from.y + offsetY,
+        to.x - offsetX,
+        to.y - offsetY,
       ]);
     }
-  }, [from, to, nodes]);
+  }, [from, to]);
 
-  return <Line points={points} stroke={"#FFCC00"} strokeWidth={3}></Line>;
+  return (
+    <Line points={points} stroke={"#FFCC00"} strokeWidth={3} {...rest}></Line>
+  );
 }

--- a/packages/frontend/src/components/Edge.tsx
+++ b/packages/frontend/src/components/Edge.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { Line } from "react-konva";
+
+import Konva from "konva";
+
+import type { Node } from "./mock";
+
+type EdgeProps = {
+  from: Node["id"];
+  to: Node["id"];
+  nodes: Node[];
+} & Konva.LineConfig;
+
+export default function Edge({ from, to, nodes }: EdgeProps) {
+  const [points, setPoints] = useState<number[]>([]);
+  const RADIUS = 64;
+
+  useEffect(() => {
+    const fromNode = nodes.find((node) => node.id === from);
+    const toNode = nodes.find((node) => node.id === to);
+
+    if (fromNode && toNode) {
+      // 두 노드 간의 방향 벡터를 계산
+      const dx = toNode.x - fromNode.x;
+      const dy = toNode.y - fromNode.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+
+      // 방향 벡터를 정규화하여 반지름만큼 떨어진 점을 계산
+      const offsetX = (dx / distance) * RADIUS;
+      const offsetY = (dy / distance) * RADIUS;
+
+      // Line의 시작점과 끝점을 각각 노드 원의 경계로 조정
+      setPoints([
+        fromNode.x + offsetX,
+        fromNode.y + offsetY,
+        toNode.x - offsetX,
+        toNode.y - offsetY,
+      ]);
+    }
+  }, [from, to, nodes]);
+
+  return <Line points={points} stroke={"#FFCC00"} strokeWidth={3}></Line>;
+}

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable no-undef */
-import { useEffect, useRef, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { Circle, Group, Text } from "react-konva";
 
 import Konva from "konva";
@@ -8,7 +7,7 @@ type NodeProps = {
   x: number;
   y: number;
   draggable?: boolean;
-  children?: React.ReactNode;
+  children?: ReactNode;
 } & Konva.GroupConfig;
 
 export default function Node({
@@ -73,7 +72,7 @@ Node.Text = function NodeText({
   );
 };
 
-type HeadNodeProps = {
+export type HeadNodeProps = {
   name: string;
 };
 
@@ -92,7 +91,7 @@ export function HeadNode({ name }: HeadNodeProps) {
   );
 }
 
-type NoteNodeProps = {
+export type NoteNodeProps = {
   x: number;
   y: number;
   src: string;

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -13,7 +13,7 @@ type NodeProps = {
 export default function Node({
   x,
   y,
-  draggable,
+  draggable = true,
   children,
   ...rest
 }: NodeProps) {
@@ -79,7 +79,7 @@ export type HeadNodeProps = {
 export function HeadNode({ name }: HeadNodeProps) {
   const radius = 64;
   return (
-    <Node x={0} y={0}>
+    <Node x={0} y={0} draggable={false}>
       <Node.Circle radius={radius} fill="#FFCC00" />
       <Node.Text
         width={radius * 2}

--- a/packages/frontend/src/components/mock.ts
+++ b/packages/frontend/src/components/mock.ts
@@ -1,13 +1,12 @@
-export type Node = {
-  id: string;
-  name: string;
-  x: number;
-  y: number;
-  type: "head" | "note" | "url" | "image" | "subspace";
-};
+import type { Edge, Node } from "shared/types";
 
 export const nodes: Node[] = [
   { id: "0", x: 0, y: 0, type: "head", name: "Hello World" },
   { id: "1", x: 100, y: 100, type: "note", name: "first" },
   { id: "2", x: -100, y: 100, type: "note", name: "second" },
+];
+
+export const edges: Edge[] = [
+  { from: nodes[0], to: nodes[1] },
+  { from: nodes[0], to: nodes[2] },
 ];

--- a/packages/frontend/src/components/mock.ts
+++ b/packages/frontend/src/components/mock.ts
@@ -1,0 +1,13 @@
+export type Node = {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  type: "head" | "note" | "url" | "image" | "subspace";
+};
+
+export const nodes: Node[] = [
+  { id: "0", x: 0, y: 0, type: "head", name: "Hello World" },
+  { id: "1", x: 100, y: 100, type: "note", name: "first" },
+  { id: "2", x: -100, y: 100, type: "note", name: "second" },
+];

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { Layer, Stage } from "react-konva";
 
-import { HeadNode, NoteNode } from "../Node.tsx";
+import Edge from "@/components/Edge";
+import { nodes } from "@/components/mock";
+
+import { HeadNode, NoteNode } from "../Node";
 
 interface SpaceViewProps {
   autofitTo?: Element | React.RefObject<Element>;
@@ -42,9 +45,26 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
   return (
     <Stage width={stageSize.width} height={stageSize.height} draggable>
       <Layer offsetX={-stageSize.width / 2} offsetY={-stageSize.height / 2}>
-        {/* <SpaceNode label="HEAD NODE" x={0} y={0} /> */}
-        <HeadNode name="Hello World" />
-        <NoteNode x={100} y={100} src={""} name={"note"} />
+        {nodes.map((node) => {
+          switch (node.type) {
+            case "head":
+              return <HeadNode key={node.id} name={node.name} />;
+            case "note":
+              return (
+                <NoteNode
+                  key={node.id}
+                  x={node.x}
+                  y={node.y}
+                  name={node.name}
+                  src=""
+                />
+              );
+            default:
+              return null;
+          }
+        })}
+        <Edge from={nodes[0].id} to={nodes[1].id} nodes={nodes} />
+        <Edge from={nodes[1].id} to={nodes[2].id} nodes={nodes} />
       </Layer>
     </Stage>
   );

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { Layer, Stage } from "react-konva";
 
-import Edge from "@/components/Edge";
-import { nodes } from "@/components/mock";
+import type { Node } from "shared/types";
 
-import { HeadNode, NoteNode } from "../Node";
+import Edge from "@/components/Edge";
+import { HeadNode, NoteNode } from "@/components/Node";
+import { edges, nodes } from "@/components/mock";
 
 interface SpaceViewProps {
   autofitTo?: Element | React.RefObject<Element>;
@@ -42,29 +43,29 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
     };
   }, [autofitTo]);
 
+  const nodeComponents = {
+    head: (node: Node) => <HeadNode key={node.id} name={node.name} />,
+    note: (node: Node) => (
+      <NoteNode key={node.id} x={node.x} y={node.y} name={node.name} src="" />
+    ),
+  };
+
   return (
     <Stage width={stageSize.width} height={stageSize.height} draggable>
       <Layer offsetX={-stageSize.width / 2} offsetY={-stageSize.height / 2}>
         {nodes.map((node) => {
-          switch (node.type) {
-            case "head":
-              return <HeadNode key={node.id} name={node.name} />;
-            case "note":
-              return (
-                <NoteNode
-                  key={node.id}
-                  x={node.x}
-                  y={node.y}
-                  name={node.name}
-                  src=""
-                />
-              );
-            default:
-              return null;
-          }
+          const Component =
+            nodeComponents[node.type as keyof typeof nodeComponents];
+          return Component ? Component(node) : null;
         })}
-        <Edge from={nodes[0].id} to={nodes[1].id} nodes={nodes} />
-        <Edge from={nodes[1].id} to={nodes[2].id} nodes={nodes} />
+        {edges.map((edge) => (
+          <Edge
+            key={`${edge.from}-${edge.to}`}
+            from={edge.from}
+            to={edge.to}
+            nodes={nodes}
+          />
+        ))}
       </Layer>
     </Stage>
   );

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -1,0 +1,12 @@
+export type Node = {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  type: "head" | "note" | "url" | "image" | "subspace";
+};
+
+export type Edge = {
+  from: Node;
+  to: Node;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 9.14.0(jiti@1.21.6)
       eslint-config-airbnb-base:
         specifier: ^15.0.0
-        version: 15.0.0(eslint-plugin-import@2.31.0(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+        version: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.14.0(jiti@1.21.6))
@@ -56,18 +56,24 @@ importers:
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/config':
+        specifier: ^3.3.0
+        version: 3.3.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
       '@nestjs/core':
         specifier: ^10.0.0
         version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/mongoose':
         specifier: ^10.1.0
-        version: 10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(mongoose@8.8.1)(rxjs@7.8.1)
+        version: 10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(mongoose@8.8.1)(rxjs@7.8.1)
       '@nestjs/platform-express':
         specifier: ^10.0.0
         version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
       '@nestjs/typeorm':
         specifier: ^10.0.2
-        version: 10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+        version: 10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       ioredis:
         specifier: ^5.4.1
         version: 5.4.1
@@ -86,6 +92,9 @@ importers:
       typeorm:
         specifier: ^0.3.20
         version: 0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3))
+      uuid:
+        specifier: ^11.0.3
+        version: 11.0.3
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
@@ -95,7 +104,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.6.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)
+        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7))
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
@@ -108,6 +117,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.2
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
         version: 8.14.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
@@ -186,6 +198,9 @@ importers:
       react-router-dom:
         specifier: ^6.28.0
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      shared:
+        specifier: workspace:*
+        version: link:../shared
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -1123,6 +1138,12 @@ packages:
       class-validator:
         optional: true
 
+  '@nestjs/config@3.3.0':
+    resolution: {integrity: sha512-pdGTp8m9d0ZCrjTpjkUbZx6gyf2IKf+7zlkrPNMsJzYZ4bFRRTpXrnj+556/5uiI6AfL5mMrJc2u7dB6bvM+VA==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
+      rxjs: ^7.1.0
+
   '@nestjs/core@10.4.7':
     resolution: {integrity: sha512-AIpQzW/vGGqSLkKvll1R7uaSNv99AxZI2EFyVJPNGDgFsfXaohfV1Ukl6f+s75Km+6Fj/7aNl80EqzNWQCS8Ig==}
     peerDependencies:
@@ -1869,6 +1890,9 @@ packages:
 
   '@types/supertest@6.0.2':
     resolution: {integrity: sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -2737,6 +2761,10 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  dotenv-expand@10.0.0:
+    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -5462,6 +5490,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.0.3:
+    resolution: {integrity: sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -6603,6 +6635,14 @@ snapshots:
       tslib: 2.7.0
       uid: 2.0.2
 
+  '@nestjs/config@3.3.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)':
+    dependencies:
+      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      dotenv: 16.4.5
+      dotenv-expand: 10.0.0
+      lodash: 4.17.21
+      rxjs: 7.8.1
+
   '@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -6619,7 +6659,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/mongoose@10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(mongoose@8.8.1)(rxjs@7.8.1)':
+  '@nestjs/mongoose@10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(mongoose@8.8.1)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -6649,7 +6689,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)':
+  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7))':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -6657,7 +6697,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
 
-  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))':
+  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -7451,6 +7491,8 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/uuid@10.0.0': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -8445,6 +8487,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  dotenv-expand@10.0.0: {}
+
   dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
@@ -8629,7 +8673,7 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 9.14.0(jiti@1.21.6)
@@ -8660,7 +8704,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.14.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -8673,7 +8717,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -8695,7 +8739,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.14.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -11470,6 +11514,8 @@ snapshots:
       which-typed-array: 1.1.15
 
   utils-merge@1.0.1: {}
+
+  uuid@11.0.3: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

노드 간의 관계를 연결하는 `Edge` 컴포넌트를 구현 후 더미 데이터로 하위 노드를 추가하여 테스트하였습니다.


## ✅ 작업 내용
- [x] 노드 관련 데이터 타입 추가
- [x] 노드 더미 데이터 생성 (mock.ts)
- [x] Edge 컴포넌트 구현

## 🏷️ 관련 이슈
- #33 
- #35 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

![Screen Recording 2024-11-14 at 7 11 13 PM](https://github.com/user-attachments/assets/a3e5ef0b-1e01-4a5c-a746-ca90b32836e8)


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

- 아직 폴더 구조가 정확히 잡히지 않은 상태인 것 같아 모든 파일들은 `components` 폴더 하위에 생성해서 작업 중입니다.

- 노드 관련 데이터 타입은 추후 `shared` 디렉토리에서 백엔드와 함께 사용하도록 해야 할 것 같습니다.

- 현재 `switch` 문을 사용하여 노드의 타입 별로 컴포넌트를 렌더링하도록 수정한 상태입니다. 혹시 더 나은 방법이 있다면 공유해주시면 적극 반영하겠습니다!