### PR TITLE
팔레트 UI 표시 후 타입 선택 시 노드 생성

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -23,6 +23,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-konva": "^18.2.10",
+    "react-konva-utils": "^1.0.6",
     "react-router-dom": "^6.28.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7"

--- a/packages/frontend/src/components/Edge.tsx
+++ b/packages/frontend/src/components/Edge.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { Line } from "react-konva";
+
+import Konva from "konva";
+
+import type { Node } from "./mock";
+
+type EdgeProps = {
+  from: Node["id"];
+  to: Node["id"];
+  nodes: Node[];
+} & Konva.LineConfig;
+
+export default function Edge({ from, to, nodes }: EdgeProps) {
+  const [points, setPoints] = useState<number[]>([]);
+  const RADIUS = 64;
+
+  useEffect(() => {
+    const fromNode = nodes.find((node) => node.id === from);
+    const toNode = nodes.find((node) => node.id === to);
+
+    if (fromNode && toNode) {
+      // 두 노드 간의 방향 벡터를 계산
+      const dx = toNode.x - fromNode.x;
+      const dy = toNode.y - fromNode.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+
+      // 방향 벡터를 정규화하여 반지름만큼 떨어진 점을 계산
+      const offsetX = (dx / distance) * RADIUS;
+      const offsetY = (dy / distance) * RADIUS;
+
+      // Line의 시작점과 끝점을 각각 노드 원의 경계로 조정
+      setPoints([
+        fromNode.x + offsetX,
+        fromNode.y + offsetY,
+        toNode.x - offsetX,
+        toNode.y - offsetY,
+      ]);
+    }
+  }, [from, to, nodes]);
+
+  return <Line points={points} stroke={"#FFCC00"} strokeWidth={3}></Line>;
+}

--- a/packages/frontend/src/components/Edge.tsx
+++ b/packages/frontend/src/components/Edge.tsx
@@ -3,12 +3,12 @@ import { Line } from "react-konva";
 
 import Konva from "konva";
 
-import type { Node } from "./mock";
+import type { NodeType } from "./mock";
 
 type EdgeProps = {
-  from: Node["id"];
-  to: Node["id"];
-  nodes: Node[];
+  from: NodeType["id"];
+  to: NodeType["id"];
+  nodes: NodeType[];
 } & Konva.LineConfig;
 
 export default function Edge({ from, to, nodes }: EdgeProps) {

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -5,21 +5,37 @@ import { Circle, Group, Text } from "react-konva";
 import Konva from "konva";
 
 type NodeProps = {
+  id: string;
   x: number;
   y: number;
   draggable?: boolean;
+  onDragStart?: (id: string) => void;
   children?: React.ReactNode;
 } & Konva.GroupConfig;
 
 export default function Node({
+  id,
   x,
   y,
   draggable,
+  onDragStart,
   children,
   ...rest
 }: NodeProps) {
+  const handleDragStart = () => {
+    if (id && onDragStart) {
+      onDragStart(id);
+    }
+  };
+
   return (
-    <Group x={x} y={y} draggable={draggable} {...rest}>
+    <Group
+      x={x}
+      y={y}
+      draggable={draggable}
+      onDragStart={handleDragStart}
+      {...rest}
+    >
       {children}
     </Group>
   );
@@ -74,13 +90,15 @@ Node.Text = function NodeText({
 };
 
 type HeadNodeProps = {
+  id: string;
   name: string;
+  onDragStart?: (id: string) => void;
 };
 
-export function HeadNode({ name }: HeadNodeProps) {
+export function HeadNode({ id, name, onDragStart }: HeadNodeProps) {
   const radius = 64;
   return (
-    <Node x={0} y={0}>
+    <Node x={0} y={0} id={id} onDragStart={onDragStart} draggable>
       <Node.Circle radius={radius} fill="#FFCC00" />
       <Node.Text
         width={radius * 2}
@@ -93,17 +111,19 @@ export function HeadNode({ name }: HeadNodeProps) {
 }
 
 type NoteNodeProps = {
+  id: string;
   x: number;
   y: number;
   src: string;
   name: string;
+  onDragStart?: (id: string) => void;
 };
 
-export function NoteNode({ x, y, name }: NoteNodeProps) {
+export function NoteNode({ id, x, y, name, onDragStart }: NoteNodeProps) {
   // TODO: src 적용 필요
   const radius = 64;
   return (
-    <Node x={x} y={y}>
+    <Node x={x} y={y} id={id} onDragStart={onDragStart} draggable>
       <Node.Circle radius={radius} fill="#FFF2CB" />
       <Node.Text fontSize={16} content={name} />
     </Node>

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -5,37 +5,21 @@ import { Circle, Group, Text } from "react-konva";
 import Konva from "konva";
 
 type NodeProps = {
-  id: string;
   x: number;
   y: number;
   draggable?: boolean;
-  onDragStart?: (id: string) => void;
   children?: React.ReactNode;
 } & Konva.GroupConfig;
 
 export default function Node({
-  id,
   x,
   y,
   draggable,
-  onDragStart,
   children,
   ...rest
 }: NodeProps) {
-  const handleDragStart = () => {
-    if (id && onDragStart) {
-      onDragStart(id);
-    }
-  };
-
   return (
-    <Group
-      x={x}
-      y={y}
-      draggable={draggable}
-      onDragStart={handleDragStart}
-      {...rest}
-    >
+    <Group x={x} y={y} draggable={draggable} {...rest}>
       {children}
     </Group>
   );
@@ -90,15 +74,14 @@ Node.Text = function NodeText({
 };
 
 type HeadNodeProps = {
-  id: string;
   name: string;
-  onDragStart?: (id: string) => void;
+  onDragStart?: () => void;
 };
 
-export function HeadNode({ id, name, onDragStart }: HeadNodeProps) {
+export function HeadNode({ name, onDragStart }: HeadNodeProps) {
   const radius = 64;
   return (
-    <Node x={0} y={0} id={id} onDragStart={onDragStart} draggable>
+    <Node x={0} y={0} onDragStart={onDragStart} draggable>
       <Node.Circle radius={radius} fill="#FFCC00" />
       <Node.Text
         width={radius * 2}
@@ -111,19 +94,18 @@ export function HeadNode({ id, name, onDragStart }: HeadNodeProps) {
 }
 
 type NoteNodeProps = {
-  id: string;
   x: number;
   y: number;
   src: string;
   name: string;
-  onDragStart?: (id: string) => void;
+  onDragStart?: () => void;
 };
 
-export function NoteNode({ id, x, y, name, onDragStart }: NoteNodeProps) {
+export function NoteNode({ x, y, name, onDragStart }: NoteNodeProps) {
   // TODO: src 적용 필요
   const radius = 64;
   return (
-    <Node x={x} y={y} id={id} onDragStart={onDragStart} draggable>
+    <Node x={x} y={y} onDragStart={onDragStart} draggable>
       <Node.Circle radius={radius} fill="#FFF2CB" />
       <Node.Text fontSize={16} content={name} />
     </Node>

--- a/packages/frontend/src/components/mock.ts
+++ b/packages/frontend/src/components/mock.ts
@@ -1,4 +1,4 @@
-export type Node = {
+export type NodeType = {
   id: string;
   name: string;
   x: number;
@@ -6,8 +6,18 @@ export type Node = {
   type: "head" | "note" | "url" | "image" | "subspace";
 };
 
-export const initialNodes: Node[] = [
+export type EdgeType = {
+  from: NodeType["id"];
+  to: NodeType["id"];
+};
+
+export const initialNodes: NodeType[] = [
   { id: "0", x: 0, y: 0, type: "head", name: "Hello World" },
   { id: "1", x: 100, y: 100, type: "note", name: "first" },
   { id: "2", x: -100, y: 100, type: "note", name: "second" },
+];
+
+export const initialEdges: EdgeType[] = [
+  { from: "0", to: "1" },
+  { from: "1", to: "2" },
 ];

--- a/packages/frontend/src/components/mock.ts
+++ b/packages/frontend/src/components/mock.ts
@@ -1,0 +1,13 @@
+export type Node = {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+  type: "head" | "note" | "url" | "image" | "subspace";
+};
+
+export const initialNodes: Node[] = [
+  { id: "0", x: 0, y: 0, type: "head", name: "Hello World" },
+  { id: "1", x: 100, y: 100, type: "note", name: "first" },
+  { id: "2", x: -100, y: 100, type: "note", name: "second" },
+];

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -1,6 +1,9 @@
-import { Image, Link, LucideIcon, NotebookPen, X } from "lucide-react";
+import { Folder, Image, Link, LucideIcon, NotebookPen, X } from "lucide-react";
 
-export type PaletteButtonType = "note" | "image" | "link" | "close";
+import { Node } from "../mock";
+
+export type CreatableNodeType = Exclude<Node["type"], "head">;
+export type PaletteButtonType = CreatableNodeType | "close";
 type Position = { top: number; left: number };
 
 type PaletteButtonProps = {
@@ -15,8 +18,9 @@ const buttonConfig: Record<
 > = {
   note: { icon: NotebookPen, color: "fill-yellow-300" },
   image: { icon: Image, color: "fill-yellow-400" },
-  link: { icon: Link, color: "fill-yellow-500" },
+  url: { icon: Link, color: "fill-yellow-500" },
   close: { icon: X, color: "fill-yellow-200" },
+  subspace: { icon: Folder, color: "fill-yellow-200" },
 };
 
 const CONTAINER_SIZE = 160;

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -1,11 +1,12 @@
 import { Image, Link, LucideIcon, NotebookPen, X } from "lucide-react";
 
-type PaletteButtonType = "note" | "image" | "link" | "close";
+export type PaletteButtonType = "note" | "image" | "link" | "close";
 type Position = { top: number; left: number };
 
 type PaletteButtonProps = {
   variant: PaletteButtonType;
   position: Position;
+  onClick: () => void;
 };
 
 const buttonConfig: Record<
@@ -23,7 +24,7 @@ const BUTTON_SIZE = 60;
 const RADIUS = 55;
 const MAX_ITEMS = 6;
 
-function PaletteButton({ variant, position }: PaletteButtonProps) {
+function PaletteButton({ variant, position, onClick }: PaletteButtonProps) {
   const { icon: Icon, color } = buttonConfig[variant];
 
   return (
@@ -35,6 +36,7 @@ function PaletteButton({ variant, position }: PaletteButtonProps) {
         width: BUTTON_SIZE,
         height: BUTTON_SIZE,
       }}
+      onClick={onClick}
     >
       <svg viewBox="0 0 100 100">
         <polygon
@@ -52,6 +54,7 @@ function PaletteButton({ variant, position }: PaletteButtonProps) {
 type PaletteMenuProps = {
   /** 팔레트 메뉴에 표시 옵션 (최대 6개) */
   items: PaletteButtonType[];
+  onSelect: (type: PaletteButtonType) => void;
 };
 
 function getPositionByIndex(index: number): Position {
@@ -65,7 +68,7 @@ function getPositionByIndex(index: number): Position {
   };
 }
 
-export default function PaletteMenu({ items }: PaletteMenuProps) {
+export default function PaletteMenu({ items, onSelect }: PaletteMenuProps) {
   if (import.meta.env.MODE === "development" && items.length > MAX_ITEMS) {
     throw new Error(
       `팔레트 메뉴는 ${MAX_ITEMS}개의 옵션만 표시할 수 있습니다.`,
@@ -88,12 +91,14 @@ export default function PaletteMenu({ items }: PaletteMenuProps) {
           top: centerOffset,
           left: centerOffset,
         }}
+        onClick={() => onSelect("close")}
       />
       {items.slice(0, MAX_ITEMS).map((variant, index) => (
         <PaletteButton
           key={`${variant}-${index}`}
           variant={variant}
           position={getPositionByIndex(index)}
+          onClick={() => onSelect(variant)}
         />
       ))}
     </div>

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { Layer, Stage } from "react-konva";
 
+import { KonvaEventObject } from "konva/lib/Node";
+import { Vector2d } from "konva/lib/types";
+
 import { HeadNode, NoteNode } from "../Node.tsx";
+import PaletteMenu, { PaletteButtonType } from "./PaletteMenu.tsx";
 
 interface SpaceViewProps {
   autofitTo?: Element | React.RefObject<Element>;
@@ -9,6 +13,60 @@ interface SpaceViewProps {
 
 export default function SpaceView({ autofitTo }: SpaceViewProps) {
   const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
+  const [palettePosition, setPalettePosition] = useState<Vector2d | null>(null);
+  const [fromNodeId, setFromNodeId] = useState<string | null>(null);
+
+  const handleDragStart = (id: string) => {
+    setFromNodeId(id);
+  };
+
+  const handleDrop = (e: KonvaEventObject<DragEvent>) => {
+    if (!fromNodeId) return;
+    const position = e.target.getStage()?.getPointerPosition();
+
+    if (!position) return;
+    setPalettePosition(position);
+  };
+
+  const handlePaletteSelect = (type: PaletteButtonType) => {
+    if (!palettePosition || !fromNodeId || type === "close") {
+      setPalettePosition(null);
+      return;
+    }
+
+    const offSet = stageSize.width / 2;
+
+    const relativeX = palettePosition.x - offSet;
+    const relativeY = palettePosition.y - offSet;
+
+    /* FIXME: Websocket 도입 후 반영 */
+    // emitNodeCreate({
+    //   parent: fromNodeId,
+    //   x: relativeX,
+    //   y: relativeY,
+    // type,
+    // });
+
+    console.log({
+      parent: fromNodeId,
+      x: relativeX,
+      y: relativeY,
+      type,
+    });
+
+    /* TODO: 로컬 상태 업데이트 (임시) */
+    // const newNode: NodeType = {
+    //   id: "sample",
+    //   x: relativeX,
+    //   y: relativeY,
+    //   type,
+    //   name: "sample",
+    // };
+    // + 렌더링되는 노드배열 상태에 추가
+
+    setPalettePosition(null);
+    setFromNodeId(null);
+  };
 
   useEffect(() => {
     if (!autofitTo) {
@@ -40,12 +98,46 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
   }, [autofitTo]);
 
   return (
-    <Stage width={stageSize.width} height={stageSize.height} draggable>
-      <Layer offsetX={-stageSize.width / 2} offsetY={-stageSize.height / 2}>
-        {/* <SpaceNode label="HEAD NODE" x={0} y={0} /> */}
-        <HeadNode name="Hello World" />
-        <NoteNode x={100} y={100} src={""} name={"note"} />
-      </Layer>
-    </Stage>
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <Stage
+        width={stageSize.width}
+        height={stageSize.height}
+        onDragEnd={handleDrop}
+        draggable={false}
+      >
+        <Layer offsetX={-stageSize.width / 2} offsetY={-stageSize.height / 2}>
+          <HeadNode
+            id={"head-sample"}
+            name="Hello World"
+            onDragStart={handleDragStart}
+          />
+          <NoteNode
+            id={"note-sample"}
+            x={100}
+            y={100}
+            src={""}
+            name={"note"}
+            onDragStart={handleDragStart}
+          />
+        </Layer>
+      </Stage>
+      {palettePosition && (
+        <div
+          style={{
+            position: "absolute",
+            left: palettePosition.x,
+            top: palettePosition.y,
+            transform: "translate(-50%, -50%)",
+            zIndex: 1,
+            pointerEvents: "auto",
+          }}
+        >
+          <PaletteMenu
+            items={["note", "image", "link"]}
+            onSelect={handlePaletteSelect}
+          />
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/frontend/src/hooks/useNodeDrag.ts
+++ b/packages/frontend/src/hooks/useNodeDrag.ts
@@ -3,53 +3,48 @@ import { useCallback, useState } from "react";
 import { KonvaEventObject } from "konva/lib/Node";
 import { Vector2d } from "konva/lib/types";
 
-import { Node } from "@/components/mock";
+import { NodeType } from "@/components/mock";
 
 import { nodeOperationTypes } from "./useNodeOperations";
 
 type useNodeDragParams = {
-  dragEnabled?: boolean;
   nodeOperations: nodeOperationTypes;
 };
 
-export function useNodeDrag({
-  dragEnabled = true,
-  nodeOperations,
-}: useNodeDragParams) {
+export function useDragNode({ nodeOperations }: useNodeDragParams) {
   const [dragState, setDragState] = useState<{
     dragStartNodeId: string | null;
-    mousePosition: Vector2d | null;
+    dropPosition: Vector2d | null;
   }>({
     dragStartNodeId: null,
-    mousePosition: null,
+    dropPosition: null,
   });
 
   // Drag 시작: 파생된 노드Id 업데이트
   const handleDragStart = (nodeId: string) => {
-    if (!dragEnabled) return;
     setDragState((prev) => ({ ...prev, dragStartNodeId: nodeId }));
   };
 
   // Drag 종료: 드롭한 위치 업데이트
   const handleDragEnd = (e: KonvaEventObject<DragEvent>) => {
-    if (!dragEnabled || !dragState.dragStartNodeId) return;
+    if (!dragState.dragStartNodeId) return;
 
-    const position = e.target.getStage()?.getPointerPosition();
+    const position = e.target.getLayer()?.getRelativePointerPosition();
     if (!position) return;
 
-    setDragState((prev) => ({ ...prev, mousePosition: position }));
+    setDragState((prev) => ({ ...prev, dropPosition: position }));
   };
 
   const handlePaletteSelect = useCallback(
-    (type: Node["type"] | "close") => {
+    (type: NodeType["type"] | "close") => {
       if (
-        !dragState.mousePosition ||
+        !dragState.dropPosition ||
         !dragState.dragStartNodeId ||
         type === "close"
       ) {
         setDragState((prev) => ({
           ...prev,
-          mousePosition: null,
+          dropPosition: null,
           dragStartNodeId: null,
         }));
         return;
@@ -57,13 +52,13 @@ export function useNodeDrag({
 
       nodeOperations.onCreateNode?.({
         parentId: dragState.dragStartNodeId,
-        position: dragState.mousePosition,
-        type: type as Node["type"],
+        position: dragState.dropPosition,
+        type: type as NodeType["type"],
       });
 
       setDragState((prev) => ({
         ...prev,
-        mousePosition: null,
+        dropPosition: null,
         dragStartNodeId: null,
       }));
     },

--- a/packages/frontend/src/hooks/useNodeDrag.ts
+++ b/packages/frontend/src/hooks/useNodeDrag.ts
@@ -1,0 +1,81 @@
+import { useCallback, useState } from "react";
+
+import { KonvaEventObject } from "konva/lib/Node";
+import { Vector2d } from "konva/lib/types";
+
+import { Node } from "@/components/mock";
+
+import { nodeOperationTypes } from "./useNodeOperations";
+
+type useNodeDragParams = {
+  dragEnabled?: boolean;
+  nodeOperations: nodeOperationTypes;
+};
+
+export function useNodeDrag({
+  dragEnabled = true,
+  nodeOperations,
+}: useNodeDragParams) {
+  const [dragState, setDragState] = useState<{
+    dragStartNodeId: string | null;
+    mousePosition: Vector2d | null;
+  }>({
+    dragStartNodeId: null,
+    mousePosition: null,
+  });
+
+  // Drag 시작: 파생된 노드Id 업데이트
+  const handleDragStart = (nodeId: string) => {
+    if (!dragEnabled) return;
+    setDragState((prev) => ({ ...prev, dragStartNodeId: nodeId }));
+  };
+
+  // Drag 종료: 드롭한 위치 업데이트
+  const handleDragEnd = (e: KonvaEventObject<DragEvent>) => {
+    if (!dragEnabled || !dragState.dragStartNodeId) return;
+
+    const position = e.target.getStage()?.getPointerPosition();
+    if (!position) return;
+
+    setDragState((prev) => ({ ...prev, mousePosition: position }));
+  };
+
+  const handlePaletteSelect = useCallback(
+    (type: Node["type"] | "close") => {
+      if (
+        !dragState.mousePosition ||
+        !dragState.dragStartNodeId ||
+        type === "close"
+      ) {
+        setDragState((prev) => ({
+          ...prev,
+          mousePosition: null,
+          dragStartNodeId: null,
+        }));
+        return;
+      }
+
+      nodeOperations.onCreateNode?.({
+        parentId: dragState.dragStartNodeId,
+        position: dragState.mousePosition,
+        type: type as Node["type"],
+      });
+
+      setDragState((prev) => ({
+        ...prev,
+        mousePosition: null,
+        dragStartNodeId: null,
+      }));
+    },
+    [dragState, nodeOperations],
+  );
+
+  return {
+    dragState,
+    handlers: {
+      handleDragStart,
+      handleDragEnd,
+      handlePaletteSelect,
+    },
+  };
+}

--- a/packages/frontend/src/hooks/useNodeOperations.ts
+++ b/packages/frontend/src/hooks/useNodeOperations.ts
@@ -1,21 +1,19 @@
-// hooks/useNodeOperations.ts
 import React, { useMemo } from "react";
 
 import { Vector2d } from "konva/lib/types";
-import { X } from "lucide-react";
 
-import { Node } from "@/components/mock";
+import { EdgeType, NodeType } from "@/components/mock";
 
 type useNodeOperationsParams = {
-  nodes: Node[];
-  setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
+  setNodes: React.Dispatch<React.SetStateAction<NodeType[]>>;
+  setEdges: React.Dispatch<React.SetStateAction<EdgeType[]>>;
   stageSize: { width: number; height: number };
 };
 
 type CreateNodeParams = {
   parentId: string;
   position: Vector2d;
-  type: Node["type"];
+  type: NodeType["type"];
 };
 
 export type nodeOperationTypes = {
@@ -23,8 +21,8 @@ export type nodeOperationTypes = {
 };
 
 export function useNodeOperations({
-  nodes,
   setNodes,
+  setEdges,
   stageSize,
 }: useNodeOperationsParams) {
   return useMemo(
@@ -33,23 +31,30 @@ export function useNodeOperations({
         const newNode = {
           id: "sampleId",
           type,
-          x: position.x - stageSize.width / 2,
-          y: position.y - stageSize.height / 2,
+          x: position.x,
+          y: position.y,
           name: "sampleName",
         };
 
-        // TODO: Websocket 통신
+        const newEdge = {
+          from: parentId,
+          to: newNode.id,
+        };
+
+        // TODO: Websocket 통신 이후 반영
         console.log({
           parentId,
           position,
           type,
+          newEdge,
         });
 
         setNodes((prev) => [...prev, newNode]);
+        setEdges((prev) => [...prev, newEdge]);
       },
 
       // TODO: 다른 노드 조작 추가
     }),
-    [stageSize, setNodes],
+    [stageSize, setNodes, setEdges],
   );
 }

--- a/packages/frontend/src/hooks/useNodeOperations.ts
+++ b/packages/frontend/src/hooks/useNodeOperations.ts
@@ -1,0 +1,55 @@
+// hooks/useNodeOperations.ts
+import React, { useMemo } from "react";
+
+import { Vector2d } from "konva/lib/types";
+import { X } from "lucide-react";
+
+import { Node } from "@/components/mock";
+
+type useNodeOperationsParams = {
+  nodes: Node[];
+  setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
+  stageSize: { width: number; height: number };
+};
+
+type CreateNodeParams = {
+  parentId: string;
+  position: Vector2d;
+  type: Node["type"];
+};
+
+export type nodeOperationTypes = {
+  onCreateNode: ({ parentId, position, type }: CreateNodeParams) => void;
+};
+
+export function useNodeOperations({
+  nodes,
+  setNodes,
+  stageSize,
+}: useNodeOperationsParams) {
+  return useMemo(
+    () => ({
+      onCreateNode: ({ parentId, position, type }: CreateNodeParams) => {
+        const newNode = {
+          id: "sampleId",
+          type,
+          x: position.x - stageSize.width / 2,
+          y: position.y - stageSize.height / 2,
+          name: "sampleName",
+        };
+
+        // TODO: Websocket 통신
+        console.log({
+          parentId,
+          position,
+          type,
+        });
+
+        setNodes((prev) => [...prev, newNode]);
+      },
+
+      // TODO: 다른 노드 조작 추가
+    }),
+    [stageSize, setNodes],
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,18 +56,24 @@ importers:
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/config':
+        specifier: ^3.3.0
+        version: 3.3.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
       '@nestjs/core':
         specifier: ^10.0.0
         version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/mongoose':
         specifier: ^10.1.0
-        version: 10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(mongoose@8.8.1)(rxjs@7.8.1)
+        version: 10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(mongoose@8.8.1)(rxjs@7.8.1)
       '@nestjs/platform-express':
         specifier: ^10.0.0
         version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
       '@nestjs/typeorm':
         specifier: ^10.0.2
-        version: 10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+        version: 10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       ioredis:
         specifier: ^5.4.1
         version: 5.4.1
@@ -86,6 +92,9 @@ importers:
       typeorm:
         specifier: ^0.3.20
         version: 0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3))
+      uuid:
+        specifier: ^11.0.3
+        version: 11.0.3
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
@@ -95,7 +104,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.6.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)
+        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7))
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
@@ -108,6 +117,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.2
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
         version: 8.14.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
@@ -183,6 +195,9 @@ importers:
       react-konva:
         specifier: ^18.2.10
         version: 18.2.10(konva@9.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-konva-utils:
+        specifier: ^1.0.6
+        version: 1.0.6(konva@9.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.28.0
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1123,6 +1138,12 @@ packages:
       class-validator:
         optional: true
 
+  '@nestjs/config@3.3.0':
+    resolution: {integrity: sha512-pdGTp8m9d0ZCrjTpjkUbZx6gyf2IKf+7zlkrPNMsJzYZ4bFRRTpXrnj+556/5uiI6AfL5mMrJc2u7dB6bvM+VA==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
+      rxjs: ^7.1.0
+
   '@nestjs/core@10.4.7':
     resolution: {integrity: sha512-AIpQzW/vGGqSLkKvll1R7uaSNv99AxZI2EFyVJPNGDgFsfXaohfV1Ukl6f+s75Km+6Fj/7aNl80EqzNWQCS8Ig==}
     peerDependencies:
@@ -1869,6 +1890,9 @@ packages:
 
   '@types/supertest@6.0.2':
     resolution: {integrity: sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -2737,6 +2761,10 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  dotenv-expand@10.0.0:
+    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -4628,6 +4656,13 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-konva-utils@1.0.6:
+    resolution: {integrity: sha512-011+jyXwadFDkbIUdlTarKwbqME0ljX1vPeW5oyLQx4rtHdcsDr43tdOdSsMT3XpZyl8clgM9I/eK0lBuBuFHg==}
+    peerDependencies:
+      konva: ^8.3.5 || ^9.0.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+
   react-konva@18.2.10:
     resolution: {integrity: sha512-ohcX1BJINL43m4ynjZ24MxFI1syjBdrXhqVxYVDw2rKgr3yuS0x/6m1Y2Z4sl4T/gKhfreBx8KHisd0XC6OT1g==}
     peerDependencies:
@@ -5442,6 +5477,12 @@ packages:
       '@types/react':
         optional: true
 
+  use-image@1.1.1:
+    resolution: {integrity: sha512-n4YO2k8AJG/BcDtxmBx8Aa+47kxY5m335dJiCQA5tTeVU4XdhrhqR6wT0WISRXwdMEOv5CSjqekDZkEMiiWaYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   use-sidecar@1.1.2:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -5461,6 +5502,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@11.0.3:
+    resolution: {integrity: sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -6603,6 +6648,14 @@ snapshots:
       tslib: 2.7.0
       uid: 2.0.2
 
+  '@nestjs/config@3.3.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)':
+    dependencies:
+      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      dotenv: 16.4.5
+      dotenv-expand: 10.0.0
+      lodash: 4.17.21
+      rxjs: 7.8.1
+
   '@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -6619,7 +6672,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/mongoose@10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(mongoose@8.8.1)(rxjs@7.8.1)':
+  '@nestjs/mongoose@10.1.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(mongoose@8.8.1)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -6649,7 +6702,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)':
+  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7))':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -6657,7 +6710,7 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
 
-  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))':
+  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)(typeorm@0.3.20(ioredis@5.4.1)(mysql2@3.11.4)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))':
     dependencies:
       '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -7451,6 +7504,8 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/uuid@10.0.0': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -8445,6 +8500,8 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
+  dotenv-expand@10.0.0: {}
+
   dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
@@ -8660,7 +8717,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.14.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -8673,7 +8730,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -8695,7 +8752,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.14.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.14.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -10612,6 +10669,14 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-konva-utils@1.0.6(konva@9.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      konva: 9.3.16
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-konva: 18.2.10(konva@9.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      use-image: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   react-konva@18.2.10(konva@9.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@types/react-reconciler': 0.28.8
@@ -11451,6 +11516,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
+  use-image@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   use-sidecar@1.1.2(@types/react@18.3.12)(react@18.3.1):
     dependencies:
       detect-node-es: 1.1.0
@@ -11470,6 +11540,8 @@ snapshots:
       which-typed-array: 1.1.15
 
   utils-merge@1.0.1: {}
+
+  uuid@11.0.3: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

팔레트 메뉴에서 타입을 선택하면, 서버에 보낼 데이터를 생성하는 로직을 구현했어요.

## ✅ 작업 내용


- [x] 노드 드래그 / 노드 CRUD 조작을 위한 커스텀 훅 설계

`useNodeOperations`: 노드/엣지 상태 관리 및 생성 로직 포함 
`useDragNode`: 드래그 인터랙션 상태 관리 및 핸들러

- [x] PaletteMenu 표시 > 타입 선택 시 > 서버에 보낼 데이터 생성 로직 구현

< 데이터 흐름 >

노드에서 드래그 시작 -> dragStartNodeId 저장
드래그 종료 시 -> dropPosition 저장
팔레트 메뉴에서 노드 타입 선택 -> 새로운 노드/엣지 생성

< 참고 >

- 현재 순수하게 작동 여부 확인 목적으로만 D&D 로직 포함 
(추후 호균님의 D&D 인터랙션으로 반영 필요)
(실제 노드 드래그는 원래 되어서는 안됨)
- `mock.ts`에 테스트용 더미 데이터 포함. shared type 선언하여 사용

## 🏷️ 관련 이슈
- closes #55 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.
![화면 기록 2024-11-18 오후 3 17 10](https://github.com/user-attachments/assets/49ece093-1a48-47be-b0e2-9fc31a5c4273)


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

- 드래그앤드롭 처리 방식이 설계에 따라 많이 바뀔 것 같습니다. (merge를 위해서라기보다, 구현 방식 공유 용도의 PR로 해석해주세요 ㅠ.ㅠ)
- 현 상황에서 로컬 우선 업데이트 & 노드 생성 - 간선 생성 트랜잭션을 신경쓰지 않았습니다. Yjs 실험실 이후 도입이 좋을까요?

`useDragNode`는 드래그가 시작된 노드 id, 드래그 상태를 통해 핸들러들을 반환해요.
`useNodeOperations`는 노드.간선 상태 관리를 통해 노드 생성.수정 등의 조작 함수들을 가진 nodeOperations 객체를 반환해요.
<img width="474" alt="image" src="https://github.com/user-attachments/assets/f0d4f92b-373d-4077-93a3-4a2720c8d724">

