### PR TITLE
스페이스 줌 기능 추가

### DIFF
--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -16,6 +16,7 @@ interface SpaceViewProps {
 export default function SpaceView({ autofitTo }: SpaceViewProps) {
   const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
   const stageRef = React.useRef<Konva.Stage>(null);
+  let animationFrameId: number | null = null;
 
   useEffect(() => {
     if (!autofitTo) {
@@ -80,15 +81,20 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
       return;
     }
 
-    stage.scale({ x: newScale, y: newScale });
-
     const newPosition = {
       x: pointerX - mousePointTo.x * newScale,
       y: pointerY - mousePointTo.y * newScale,
     };
 
-    stage.position(newPosition);
-    stage.batchDraw();
+    if (animationFrameId) {
+      cancelAnimationFrame(animationFrameId);
+    }
+
+    animationFrameId = requestAnimationFrame(() => {
+      stage.scale({ x: newScale, y: newScale });
+      stage.position(newPosition);
+      stage.batchDraw();
+    });
   };
 
   const nodeComponents = {

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -53,8 +53,11 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
       return;
     }
     const stage = stageRef.current;
-    const scaleBy = 1.1;
+
     const oldScale = stage.scaleX();
+    const scaleBy = 1.1;
+    const MIN_SCALE = 0.5;
+    const MAX_SCALE = 2.5;
 
     const { x: pointerX = 0, y: pointerY = 0 } =
       stage.getPointerPosition() ?? {};
@@ -64,8 +67,14 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
       y: pointerY / oldScale - stage.y() / oldScale,
     };
 
-    const newScale =
+    let newScale =
       event.evt.deltaY > 0 ? oldScale * scaleBy : oldScale / scaleBy;
+
+    newScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, newScale));
+
+    if (newScale === oldScale) {
+      return;
+    }
 
     stage.scale({ x: newScale, y: newScale });
 

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -49,6 +49,10 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
   const zoomSpace = (event: KonvaEventObject<WheelEvent, Konva.Node>) => {
     event.evt.preventDefault();
 
+    if (!event.evt.ctrlKey && !event.evt.metaKey) {
+      return;
+    }
+
     if (!stageRef.current) {
       return;
     }

--- a/packages/frontend/src/hooks/useZoomSpace.ts
+++ b/packages/frontend/src/hooks/useZoomSpace.ts
@@ -3,6 +3,36 @@ import React, { useRef } from "react";
 import Konva from "konva";
 import { KonvaEventObject } from "konva/lib/Node";
 
+const getMousePointTo = (
+  stage: Konva.Stage,
+  pointer: { x: number; y: number },
+  oldScale: number,
+) => {
+  return {
+    x: (pointer.x - stage.x()) / oldScale,
+    y: (pointer.y - stage.y()) / oldScale,
+  };
+};
+
+const calculateNewScale = (
+  oldScale: number,
+  deltaY: number,
+  scaleBy: number,
+) => {
+  return deltaY > 0 ? oldScale * scaleBy : oldScale / scaleBy;
+};
+
+const calculateNewPosition = (
+  pointer: { x: number; y: number },
+  mousePointTo: { x: number; y: number },
+  newScale: number,
+) => {
+  return {
+    x: pointer.x - mousePointTo.x * newScale,
+    y: pointer.y - mousePointTo.y * newScale,
+  };
+};
+
 interface UseZoomSpaceProps {
   stageRef: React.RefObject<Konva.Stage>;
   scaleBy?: number;
@@ -32,13 +62,8 @@ export function useZoomSpace({
 
       if (!pointer) return;
 
-      const mousePointTo = {
-        x: (pointer.x - stage.x()) / oldScale,
-        y: (pointer.y - stage.y()) / oldScale,
-      };
-
-      let newScale =
-        event.evt.deltaY > 0 ? oldScale * scaleBy : oldScale / scaleBy;
+      const mousePointTo = getMousePointTo(stage, pointer, oldScale);
+      let newScale = calculateNewScale(oldScale, event.evt.deltaY, scaleBy);
 
       newScale = Math.max(minScale, Math.min(maxScale, newScale));
 
@@ -46,10 +71,7 @@ export function useZoomSpace({
         return;
       }
 
-      const newPosition = {
-        x: pointer.x - mousePointTo.x * newScale,
-        y: pointer.y - mousePointTo.y * newScale,
-      };
+      const newPosition = calculateNewPosition(pointer, mousePointTo, newScale);
 
       if (animationFrameId.current) {
         cancelAnimationFrame(animationFrameId.current);

--- a/packages/frontend/src/hooks/useZoomSpace.ts
+++ b/packages/frontend/src/hooks/useZoomSpace.ts
@@ -1,0 +1,67 @@
+import React, { useRef } from "react";
+
+import Konva from "konva";
+import { KonvaEventObject } from "konva/lib/Node";
+
+interface UseZoomSpaceProps {
+  stageRef: React.RefObject<Konva.Stage>;
+  scaleBy?: number;
+  minScale?: number;
+  maxScale?: number;
+}
+
+export function useZoomSpace({
+  stageRef,
+  scaleBy = 1.05,
+  minScale = 0.5,
+  maxScale = 2.5,
+}: UseZoomSpaceProps) {
+  const animationFrameId = useRef<number | null>(null);
+
+  const zoomSpace = (event: KonvaEventObject<WheelEvent>) => {
+    event.evt.preventDefault();
+
+    if (!event.evt.ctrlKey && !event.evt.metaKey) {
+      return;
+    }
+
+    if (stageRef.current !== null) {
+      const stage = stageRef.current;
+      const oldScale = stage.scaleX();
+      const pointer = stage.getPointerPosition();
+
+      if (!pointer) return;
+
+      const mousePointTo = {
+        x: (pointer.x - stage.x()) / oldScale,
+        y: (pointer.y - stage.y()) / oldScale,
+      };
+
+      let newScale =
+        event.evt.deltaY > 0 ? oldScale * scaleBy : oldScale / scaleBy;
+
+      newScale = Math.max(minScale, Math.min(maxScale, newScale));
+
+      if (newScale === oldScale) {
+        return;
+      }
+
+      const newPosition = {
+        x: pointer.x - mousePointTo.x * newScale,
+        y: pointer.y - mousePointTo.y * newScale,
+      };
+
+      if (animationFrameId.current) {
+        cancelAnimationFrame(animationFrameId.current);
+      }
+
+      animationFrameId.current = requestAnimationFrame(() => {
+        stage.scale({ x: newScale, y: newScale });
+        stage.position(newPosition);
+        stage.batchDraw();
+      });
+    }
+  };
+
+  return { zoomSpace };
+}


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

스페이스에서 `ctrl` 또는 `cmd` 키 + 스크롤 시 확대/축소 기능이 동작하도록 기능을 추가하였습니다.


## ✅ 작업 내용
- [x] 기본 줌 동작 기능 구현
- [x] 최대/최소 스케일 설정 및 예외 처리
- [x] 렌더링 성능 개선
- [x] 커스텀 훅 및 유틸 함수 분리

## 🏷️ 관련 이슈
- #48

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

![Screen Recording 2024-11-21 at 12 27 14 PM](https://github.com/user-attachments/assets/4302e76e-38b1-45e4-8150-44e4989b777a)


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)
- 기존에는 구현 시 스크롤만 수행하더라도 확대/축소가 가능하도록 구현했다가, 다른 에디터 툴 (ex. 엑스칼리드로우, 피그마)를 참고하여 브라우저의 기본 스크롤 동작을 살릴 수 있도록 **ctrl/cmd 키 + 스크롤 조합 시** 줌 기능이 동작하도록 수정하였습니다. 기획에 정의되지 않았던 부분이라 제 임의대로 처리하였는데, 다른 분들이 생각하시기엔 어떤지 궁금합니다!

- 현재 분리한 유틸 함수들은 재사용될지에 대한 여부가 모호하다고 판단해 커스텀 훅 파일 안에 둔 상태입니다. 혹시 다른 의견을 가지고 계시다면 제시해 주시면 감사하겠습니다.