### PR TITLE
화면 조작 후 드래그 시작노드 위치 오류 & GooeyConnection 조절점 오류 수정

### DIFF
--- a/packages/frontend/src/components/space/GooeyNode.tsx
+++ b/packages/frontend/src/components/space/GooeyNode.tsx
@@ -18,7 +18,7 @@ export default function GooeyNode({
       <Circle
         x={dragPosition.x}
         y={dragPosition.y}
-        radius={60}
+        radius={64}
         fill="#FFF2CB"
       />
       <GooeyConnection

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -95,7 +95,7 @@ function PaletteButton({ variant, position, onClick }: PaletteButtonProps) {
 type PaletteMenuProps = {
   /** 팔레트 메뉴에 표시 옵션 (최대 6개) */
   items: PaletteButtonType[];
-  onSelect: (type: PaletteButtonType, name: string | undefined) => void;
+  onSelect: (type: PaletteButtonType, name?: string) => void;
 };
 
 function getPositionByIndex(index: number): Position {
@@ -129,7 +129,7 @@ export default function PaletteMenu({ items, onSelect }: PaletteMenuProps) {
       return;
     }
 
-    onSelect(type, undefined);
+    onSelect(type);
   };
 
   return (

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -33,12 +33,9 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
   const { startNode, handlers } = drag;
 
   function createDragBoundFunc(node: Node) {
-    return function dragBoundFunc() {
+    return function dragBoundFunc(this: Konva.Node) {
       /** 원래 위치로 고정. stage도 draggable하므로 Layer에 적용된 offset을 보정하여 절대 위치로 표시.  */
-      return {
-        x: node.x + stageSize.width / 2,
-        y: node.y + stageSize.height / 2,
-      };
+      return this.absolutePosition();
     };
   }
 

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -14,6 +14,10 @@ import { useZoomSpace } from "@/hooks/useZoomSpace.ts";
 import GooeyNode from "./GooeyNode";
 import PaletteMenu from "./PaletteMenu";
 
+const dragBoundFunc = function (this: Konva.Node) {
+  return this.absolutePosition();
+};
+
 interface SpaceViewProps {
   autofitTo?: Element | React.RefObject<Element>;
 }
@@ -31,13 +35,6 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
     },
   });
   const { startNode, handlers } = drag;
-
-  function createDragBoundFunc() {
-    return function dragBoundFunc(this: Konva.Node) {
-      /** 원래 위치로 고정. stage도 draggable하므로 Layer에 적용된 offset을 보정하여 절대 위치로 표시.  */
-      return this.absolutePosition();
-    };
-  }
 
   useEffect(() => {
     if (!autofitTo) {
@@ -76,7 +73,7 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
         onDragStart={() => handlers.onDragStart(node)}
         onDragMove={handlers.onDragMove}
         onDragEnd={handlers.onDragEnd}
-        dragBoundFunc={createDragBoundFunc()}
+        dragBoundFunc={dragBoundFunc}
       />
     ),
     note: (node: Node) => (
@@ -89,7 +86,7 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
         onDragStart={() => handlers.onDragStart(node)}
         onDragMove={handlers.onDragMove}
         onDragEnd={handlers.onDragEnd}
-        dragBoundFunc={createDragBoundFunc()}
+        dragBoundFunc={dragBoundFunc}
       />
     ),
   };

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -32,7 +32,7 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
   });
   const { startNode, handlers } = drag;
 
-  function createDragBoundFunc(node: Node) {
+  function createDragBoundFunc() {
     return function dragBoundFunc(this: Konva.Node) {
       /** 원래 위치로 고정. stage도 draggable하므로 Layer에 적용된 offset을 보정하여 절대 위치로 표시.  */
       return this.absolutePosition();
@@ -76,7 +76,7 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
         onDragStart={() => handlers.onDragStart(node)}
         onDragMove={handlers.onDragMove}
         onDragEnd={handlers.onDragEnd}
-        dragBoundFunc={createDragBoundFunc(node)}
+        dragBoundFunc={createDragBoundFunc()}
       />
     ),
     note: (node: Node) => (
@@ -89,7 +89,7 @@ export default function SpaceView({ autofitTo }: SpaceViewProps) {
         onDragStart={() => handlers.onDragStart(node)}
         onDragMove={handlers.onDragMove}
         onDragEnd={handlers.onDragEnd}
-        dragBoundFunc={createDragBoundFunc(node)}
+        dragBoundFunc={createDragBoundFunc()}
       />
     ),
   };

--- a/packages/frontend/src/hooks/useDragNode.ts
+++ b/packages/frontend/src/hooks/useDragNode.ts
@@ -53,10 +53,7 @@ export default function useDragNode(spaceActions: spaceActions) {
     }));
   };
 
-  const handlePaletteSelect = (
-    type: PaletteButtonType,
-    name: string | undefined,
-  ) => {
+  const handlePaletteSelect = (type: PaletteButtonType, name: string = "") => {
     const { startNode } = dragState;
 
     // FIXME: note 타입 외의 노드 생성 동작을 임시로 막음.

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -43,7 +43,7 @@ export const getDistanceFromPoints: getDistanceFromPoints = (
   }
 
   const dx = secondPoint.x - firstPoint.x;
-  const dy = secondPoint.y - secondPoint.y;
+  const dy = secondPoint.y - firstPoint.y;
   const distance = Math.sqrt(dx * dx + dy * dy);
 
   return distance;


### PR DESCRIPTION
## ✏️ 한 줄 설명
화면을 움직인 후에 드래그를 시작한 노드의 위치가 이상하게 표시되는 오류를 수정했어요.

## ✅ 작업 내용 

아래의 문제를 해결했어요. (+ 현진님께서 고쳐주셨던 palettemenu의 onSelect 매개변수 타입 오류를 수정했어요)
![image](https://github.com/user-attachments/assets/a90433d5-38f3-4dce-a6b0-a8acc5532407)

## 🏷️ 관련 이슈
- #55 
- #54 

## 📸 스크린샷/영상
- (현재 dev 최신코드가 아직 websocket 오류가 있어서, dev 반영 이전 제 코드에서 테스트해봤어요)
- createDragFunc의 반환값만 수정하는 내용이라 이후 dev 내용을 반영해도 문제가 없을 것 같습니다.

![fix-드래그후생성](https://github.com/user-attachments/assets/f1683cc1-217a-413b-9a14-3e0d3b122afa)

###  Gooey 표현 수정한 오류 내용
<img width="723" alt="image" src="https://github.com/user-attachments/assets/053bfb25-196f-4d40-8846-132270764b7d">

### Gooey 표현 개선한 내용
<img width="724" alt="image" src="https://github.com/user-attachments/assets/ae526d31-4524-49de-8b58-12a84f92d49c">


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

( 오류 수정이라 리뷰는 딱히 필요없을 것 같은데, getAbsolutePosition 외에 Konva에서 더 지혜롭게 활용할 수 있는 방식이 있다면 알려주시면 좋을 것 같아요 )
