### PR TITLE
웹소켓 백엔드 측 주소 변경사항 반영 및 dev/production 다르게 반영

### DIFF
--- a/packages/frontend/nginx.conf
+++ b/packages/frontend/nginx.conf
@@ -12,7 +12,7 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options "nosniff";
     add_header Referrer-Policy "strict-origin-when-cross-origin";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://localhost;";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws://www.honeyflow.life;";
     
     # gzip 설정
     gzip on;

--- a/packages/frontend/src/components/note/Editor.tsx
+++ b/packages/frontend/src/components/note/Editor.tsx
@@ -19,7 +19,7 @@ function MilkdownEditor() {
 
   useMilkdownCollab({
     editor: loading ? null : get() || null,
-    websocketUrl: "ws://localhost/note",
+    websocketUrl: `ws://${import.meta.env.DEV ? "localhost" : "www.honeyflow.life"}/ws/note`,
     roomName: noteId || "",
   });
   return <Milkdown />;

--- a/packages/frontend/src/hooks/yjs/useYjsConnection.tsx
+++ b/packages/frontend/src/hooks/yjs/useYjsConnection.tsx
@@ -10,8 +10,7 @@ export default function useYjsConnection(docName: string) {
   useEffect(() => {
     const doc = new Y.Doc();
     const provider = new WebsocketProvider(
-      // `ws://${import.meta.env.DEV ? "localhost" : "www.honeyflow.life"}/space`,
-      `ws://${"localhost"}/space`,
+      `ws://${import.meta.env.DEV ? "localhost" : "www.honeyflow.life"}/ws/space`,
       docName,
       doc,
     );


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

웹소켓 접속 주소가 localhost였던 문제를 해결하고, 웹 소켓 주소가 `/ws/...` 바뀐 것을 반영했습니다.

## ✅ 작업 내용

- space와 note에 대해 웹 소켓 주소가 잘못된 것을 수정했습니다.
- 빌드 시 dev이면 localhost, production이면 배포 주소가 되도록 하였습니다.
- Content Security Policy directive 문제를 해결하기 위해 nginx.conf를 수정했습니다.

## 🏷️ 관련 이슈
- 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)