### PR TITLE
frontend 개발 단계에서 yDoc 태스크 의존성 분리를 위한 mock 설정

### DIFF
--- a/packages/frontend/src/hooks/useYjsSpace.tsx
+++ b/packages/frontend/src/hooks/useYjsSpace.tsx
@@ -8,9 +8,28 @@ import { useYjsStore } from "@/store/yjs";
 
 import useY from "./yjs/useY";
 
+const MOCK_DATA = {
+  nodes: {
+    root: {
+      id: "root",
+      type: "head" as const,
+      name: "허니의 스페이스",
+      x: 0,
+      y: 0,
+    },
+  },
+  edges: {},
+};
+
 export default function useYjsSpace() {
   const { yDoc, yProvider } = useYjsStore();
   const [yContext, setYContext] = useState<Y.Map<unknown>>();
+
+  useEffect(() => {
+    if (!yDoc) return;
+    const context = yDoc.getMap("context");
+    setYContext(context);
+  }, [yDoc]);
 
   // TODO 코드 개선
   const yNodes = yContext?.get("nodes") as Y.Map<Node> | undefined;
@@ -108,5 +127,28 @@ export default function useYjsSpace() {
     return () => yProvider.off("sync", handleOnSync);
   }, [yDoc, yProvider]);
 
+  /* NOTE - 개발 단계에서 프론트엔드 Space 개발을 위한 Mock 데이터 임의 설정 */
+  if (!yDoc || !nodes || Object.keys(nodes || {}).length === 0) {
+    // mock 상태일 때도 yDoc에 초기 데이터 설정
+    if (yDoc && yContext) {
+      const yNodes = new Y.Map();
+      const yEdges = new Y.Map();
+
+      yDoc.transact(() => {
+        // root 노드 설정
+        yNodes.set(MOCK_DATA.nodes.root.id, MOCK_DATA.nodes.root);
+        yContext.set("nodes", yNodes);
+        yContext.set("edges", yEdges);
+      });
+    }
+
+    return {
+      nodes: MOCK_DATA.nodes,
+      edges: MOCK_DATA.edges,
+      defineNode,
+      updateNode,
+      deleteNode,
+    };
+  }
   return { nodes, edges, updateNode, defineNode, deleteNode };
 }


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

yjs 연동 작업의 영향을 받지 않고 개발단계에서 space에 노드를 표시하며 테스트할 수 있도록 만드는 것이 목적이에요.
이를 위해 yDoc이 비어있을 때 mock 데이터를 넣어줘요.

## ✅ 작업 내용
- yDoc이 비어있을 때 mock 데이터 사용

## 🏷️ 관련 이슈
- X (이후에 프로덕션 코드에서는 다시 빼야해요...)

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

아래와 같이 기본 head node 하나를 mock 데이터에 넣어놨어요. 
<img width="1552" alt="스크린샷 2024-11-26 오전 12 44 08" src="https://github.com/user-attachments/assets/590530cf-4878-4be9-ac4c-0445190981ff">



## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

순전히 개발 단계를 위한 "임시적인"내용인데 dev로 병합되는 게 조금 걱정이긴 합니다.
이 방식보다 더 좋은 방법을 제안해주셔도 좋을 것 같아요!