### PR TITLE
API 연결하여 노트 생성 및 이동

### DIFF
--- a/packages/frontend/src/api/note.ts
+++ b/packages/frontend/src/api/note.ts
@@ -1,0 +1,19 @@
+import { API_V1_URL } from "./constants";
+import http from "./http";
+
+type CreateNoteRequestBody = {
+  userId: string;
+  noteName: string;
+};
+
+type CreateNoteResponseBody = {
+  urlPath: [string];
+};
+
+export async function createNote(body: CreateNoteRequestBody) {
+  const response = await http.post<CreateNoteResponseBody>(
+    `${API_V1_URL}/note`,
+    { body: JSON.stringify(body) },
+  );
+  return response.data;
+}

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -109,11 +109,12 @@ export type NoteNodeProps = {
   name: string;
 } & NodeHandlers;
 
-export function NoteNode({ x, y, name, ...rest }: NoteNodeProps) {
+export function NoteNode({ x, y, name, src, ...rest }: NoteNodeProps) {
   // TODO: src 적용 필요
+  const navigate = useNavigate();
   const radius = 64;
   return (
-    <Node x={x} y={y} {...rest}>
+    <Node x={x} y={y} onClick={() => navigate(`/note/${src}`)} {...rest}>
       <Node.Circle radius={radius} fill="#FFF2CB" />
       <Node.Text fontSize={16} content={name} />
     </Node>

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -5,6 +5,7 @@ import { Html } from "react-konva-utils";
 import Konva from "konva";
 import type { Node } from "shared/types";
 
+import { createNote } from "@/api/note";
 import { createSpace } from "@/api/space";
 import Edge from "@/components/Edge";
 import { HeadNode, NoteNode, SubspaceNode } from "@/components/Node";
@@ -38,18 +39,23 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
   const { drag, dropPosition, handlePaletteSelect } = useDragNode(nodesArray, {
     createNode: (type, parentNode, position, name = "New Note") => {
       if (type === "note") {
-        const src = "";
         // FIXME: note 생성 후 id 입력
-        defineNode(
-          {
-            type,
-            x: position.x,
-            y: position.y,
-            name,
-            src,
-          },
-          parentNode.id,
-        );
+        createNote({
+          userId: "honeyflow",
+          noteName: name,
+        }).then((res) => {
+          const [urlPath] = res.urlPath;
+          defineNode(
+            {
+              type,
+              x: position.x,
+              y: position.y,
+              name,
+              src: urlPath,
+            },
+            parentNode.id,
+          );
+        });
 
         return;
       }

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -39,19 +39,17 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
   const { drag, dropPosition, handlePaletteSelect } = useDragNode(nodesArray, {
     createNode: (type, parentNode, position, name = "New Note") => {
       if (type === "note") {
-        // FIXME: note 생성 후 id 입력
         createNote({
           userId: "honeyflow",
           noteName: name,
         }).then((res) => {
-          const [urlPath] = res.urlPath;
           defineNode(
             {
               type,
               x: position.x,
               y: position.y,
               name,
-              src: urlPath,
+              src: res.urlPath.toString(),
             },
             parentNode.id,
           );
@@ -118,7 +116,7 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
         x={node.x}
         y={node.y}
         name={node.name}
-        src=""
+        src={node.src}
         onDragStart={() => handlers.onDragStart(node)}
         onDragMove={handlers.onDragMove}
         onDragEnd={handlers.onDragEnd}

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Layer, Stage } from "react-konva";
 import { Html } from "react-konva-utils";
 
@@ -38,7 +38,7 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
   const { drag, dropPosition, handlePaletteSelect } = useDragNode(nodesArray, {
     createNode: (type, parentNode, position, name = "New Note") => {
       if (type === "note") {
-        let src = "";
+        const src = "";
         // FIXME: note 생성 후 id 입력
         defineNode(
           {
@@ -87,7 +87,6 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
         parentNode.id,
       );
     },
-
     createEdge: (fromNode, toNode) => {
       defineEdge(fromNode.id, toNode.id);
     },

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Layer, Stage } from "react-konva";
 import { Html } from "react-konva-utils";
 

--- a/packages/frontend/src/components/space/YjsSpaceView.tsx
+++ b/packages/frontend/src/components/space/YjsSpaceView.tsx
@@ -1,0 +1,24 @@
+import { RefObject } from "react";
+
+import useYjsConnection from "@/hooks/yjs/useYjsConnection";
+import { YjsStoreProvider } from "@/store/yjs";
+
+import SpaceView from "./SpaceView";
+
+type YjsSpaceViewProps = {
+  spaceId: string;
+  autofitTo?: Element | RefObject<Element>;
+};
+
+export default function YjsSpaceView({
+  spaceId,
+  autofitTo,
+}: YjsSpaceViewProps) {
+  const { yDoc, yProvider, setYDoc, setYProvider } = useYjsConnection(spaceId);
+
+  return (
+    <YjsStoreProvider value={{ yDoc, yProvider, setYDoc, setYProvider }}>
+      <SpaceView spaceId={spaceId} autofitTo={autofitTo} />
+    </YjsStoreProvider>
+  );
+}

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -23,7 +23,7 @@ export default function SpacePage() {
   return (
     <YjsStoreProvider value={{ yDoc, yProvider, setYDoc, setYProvider }}>
       <div className="w-full h-full" ref={containerRef}>
-        <SpaceView autofitTo={containerRef} />
+        <SpaceView spaceId={spaceId} autofitTo={containerRef} />
         <SpacePageHeader />
       </div>
     </YjsStoreProvider>


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

팔레트에서 노트 생성 후 노트 노드를 클릭했을 때 해당 노트로 진입할 수 있도록 기능을 구현하였습니다.

## ✅ 작업 내용
- 노트 생성 함수 구현
- 노드 생성 시 노트 노드일 경우 노트 생성 함수가 실행되도록 로직 추가
- 노트 클릭 시 해당 노트의 url로 이동하도록 로직 추가

## 🏷️ 관련 이슈
- closes #45 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

![Screen Recording 2024-11-27 at 7 26 15 PM](https://github.com/user-attachments/assets/b0ac6362-872e-441e-be08-419971cef9c7)

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

- 호균님이 서브스페이스 작업한 부분이 머지되지 않아 해당 브랜치에서 dev 브랜치 pull한 뒤 브랜치 파생하여 작업하였습니다. 그래서 커밋 내역이 좀 겹치게 된 부분이 있으니 참고 부탁드립니다! (squash로 해결 예정..)
- `SpaceView.ts`, `api/note.ts`, `Node.tsx` 파일 정도만 봐주시면 될 것 같습니다!