### PR TITLE
트랙패드 줌인줌아웃 방향 수정

### DIFF
--- a/packages/frontend/src/hooks/useZoomSpace.ts
+++ b/packages/frontend/src/hooks/useZoomSpace.ts
@@ -63,7 +63,12 @@ export function useZoomSpace({
       if (!pointer) return;
 
       const mousePointTo = getMousePointTo(stage, pointer, oldScale);
-      let newScale = calculateNewScale(oldScale, event.evt.deltaY, scaleBy);
+
+      const adjustedDeltaY = event.evt.ctrlKey
+        ? -event.evt.deltaY
+        : event.evt.deltaY;
+
+      let newScale = calculateNewScale(oldScale, adjustedDeltaY, scaleBy);
 
       newScale = Math.max(minScale, Math.min(maxScale, newScale));
 

--- a/packages/frontend/src/hooks/useZoomSpace.ts
+++ b/packages/frontend/src/hooks/useZoomSpace.ts
@@ -51,15 +51,14 @@ export function useZoomSpace({
   const zoomSpace = (event: KonvaEventObject<WheelEvent>) => {
     event.evt.preventDefault();
 
-    const isTrackpadGesture =
-      event.evt.deltaMode === WheelEvent.DOM_DELTA_PIXEL && event.evt.ctrlKey;
-    const isCommandWheelZoom =
-      event.evt.deltaMode === WheelEvent.DOM_DELTA_LINE && event.evt.metaKey;
     const isControlWheelZoom =
       event.evt.deltaMode === WheelEvent.DOM_DELTA_LINE && event.evt.ctrlKey;
+    const isTrackpadGesture =
+      event.evt.deltaMode === WheelEvent.DOM_DELTA_PIXEL && event.evt.ctrlKey;
 
-    // command + 휠이나 트랙패드만 허용하고 ctrl + 휠은 차단
-    if ((!isTrackpadGesture && !isCommandWheelZoom) || isControlWheelZoom) {
+    // NOTE - 마우스휠 동작 방향 반대로 수정할 수 있는지 검토 필요
+    // [ctrl + 마우스휠] 또는 [트랙패드 제스처]만 허용
+    if (!isControlWheelZoom && !isTrackpadGesture) {
       return;
     }
 

--- a/packages/frontend/src/hooks/useZoomSpace.ts
+++ b/packages/frontend/src/hooks/useZoomSpace.ts
@@ -51,7 +51,15 @@ export function useZoomSpace({
   const zoomSpace = (event: KonvaEventObject<WheelEvent>) => {
     event.evt.preventDefault();
 
-    if (!event.evt.ctrlKey && !event.evt.metaKey) {
+    const isTrackpadGesture =
+      event.evt.deltaMode === WheelEvent.DOM_DELTA_PIXEL && event.evt.ctrlKey;
+    const isCommandWheelZoom =
+      event.evt.deltaMode === WheelEvent.DOM_DELTA_LINE && event.evt.metaKey;
+    const isControlWheelZoom =
+      event.evt.deltaMode === WheelEvent.DOM_DELTA_LINE && event.evt.ctrlKey;
+
+    // command + 휠이나 트랙패드만 허용하고 ctrl + 휠은 차단
+    if ((!isTrackpadGesture && !isCommandWheelZoom) || isControlWheelZoom) {
       return;
     }
 
@@ -64,11 +72,7 @@ export function useZoomSpace({
 
       const mousePointTo = getMousePointTo(stage, pointer, oldScale);
 
-      const adjustedDeltaY = event.evt.ctrlKey
-        ? -event.evt.deltaY
-        : event.evt.deltaY;
-
-      let newScale = calculateNewScale(oldScale, adjustedDeltaY, scaleBy);
+      let newScale = calculateNewScale(oldScale, -event.evt.deltaY, scaleBy);
 
       newScale = Math.max(minScale, Math.min(maxScale, newScale));
 


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

트랙패드를 통한 화면 조작 시 줌인줌아웃이 반대 방향으로 동작하던 것을 수정했어요. 

## ✅ 작업 내용
- deltaY 연산 방식 수정

## 🏷️ 관련 이슈
- #48 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

`트랙패드`: 일반적으로 아는 방식으로 동작 [손가락 벌릴 때 확대] / [손가락 오므릴 때 축소]
`ctrlKey + 마우스휠`: 휠을 위로 굴릴 때 축소 / 아래로 굴릴 때 확대

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

여러 가지 시도해봤는데, 트랙패드와 ctrlKey + 마우스휠 동작 2가지 모두를 저희가 아는 방식으로 구현하는 것에 문제가 있습니다.
일단 트랙패드의 줌인줌아웃을 보편적으로 가는 것이 더 중요하다고 생각하여 우선순위를 높게 가져갔습니다.

(macOS에서 트랙패드 제스쳐 시 ctrlKey를 자동활성화함 + 마우스휠과 트랙패드의 동작 시 deltaY 해석 방식이 달라짐)