### PR TITLE
prompt dialog 구현

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,20 +2,24 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import "./App.css";
 import Editor from "./components/note/Editor.tsx";
+import { PromptDialogPortal } from "./lib/prompt-dialog.tsx";
 import Home from "./pages/Home.tsx";
 import NotFoundPage from "./pages/NotFound.tsx";
 import SpacePage from "./pages/Space.tsx";
 
 function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/space/:spaceId" element={<SpacePage />} />
-        <Route path="/note/:noteId" element={<Editor />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
-    </BrowserRouter>
+    <>
+      <PromptDialogPortal />
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/space/:spaceId" element={<SpacePage />} />
+          <Route path="/note/:noteId" element={<Editor />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </BrowserRouter>
+    </>
   );
 }
 

--- a/packages/frontend/src/components/SpaceShareAlertContent.tsx
+++ b/packages/frontend/src/components/SpaceShareAlertContent.tsx
@@ -1,0 +1,57 @@
+import { useRef, useState } from "react";
+
+import { CheckIcon, ClipboardCopyIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { Button } from "./ui/button";
+
+export default function SpaceShareAlertContent() {
+  const [hasCopied, setHasCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  const handleClickCopy = () => {
+    async function copyToClipboard() {
+      await navigator.clipboard.writeText(window.location.href);
+      setHasCopied(true);
+
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = window.setTimeout(() => {
+        setHasCopied(false);
+      }, 2000);
+    }
+
+    copyToClipboard();
+  };
+
+  return (
+    <div>
+      <div>아래 주소를 공유해주세요</div>
+      <pre className="p-2 mt-4 rounded-md bg-muted text-muted-foreground select-all text-wrap">
+        {window.location.href}
+      </pre>
+      <div className="mt-4 text-right">
+        <Button
+          variant={hasCopied ? "ghost" : "default"}
+          className={cn("transition")}
+          onClick={handleClickCopy}
+        >
+          {hasCopied ? (
+            <>
+              <CheckIcon />
+              복사 완료
+            </>
+          ) : (
+            <>
+              <ClipboardCopyIcon />
+              복사하기
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/space/PaletteMenu.tsx
+++ b/packages/frontend/src/components/space/PaletteMenu.tsx
@@ -4,6 +4,7 @@ import { Folder, Image, Link, LucideIcon, NotebookPen, X } from "lucide-react";
 import { Node } from "shared/types";
 
 import { circle, hexagon } from "@/assets/shapes";
+import { prompt } from "@/lib/prompt-dialog";
 
 export type PaletteButtonType = Exclude<Node["type"], "head"> | "close";
 type Position = { top: number; left: number };
@@ -117,13 +118,19 @@ export default function PaletteMenu({ items, onSelect }: PaletteMenuProps) {
   }
 
   const centerOffset = CONTAINER_SIZE / 2 - BUTTON_SIZE / 2;
-  const handleButtonClick = (type: PaletteButtonType) => {
+  const handleButtonClick = async (type: PaletteButtonType) => {
     if (type === "note" || type === "subspace") {
       const message = {
-        note: "노트 제목을 입력해주세요.",
-        subspace: "스페이스 이름을 입력해주세요.",
+        note: "새로운 노트",
+        subspace: "새로운 서브스페이스",
       };
-      const name = window.prompt(message[type]);
+
+      const { name } = await prompt(message[type], null, {
+        label: "제목",
+        name: "name",
+        placeholder: "제목을 입력하세요",
+      }).catch(() => ({ name: undefined }));
+
       if (name) onSelect(type, name);
 
       return;

--- a/packages/frontend/src/components/space/SpacePageHeader.tsx
+++ b/packages/frontend/src/components/space/SpacePageHeader.tsx
@@ -1,3 +1,5 @@
+import { prompt } from "@/lib/prompt-dialog";
+
 import SpaceBreadcrumb from "../SpaceBreadcrumb";
 import SpaceUsersIndicator from "../SpaceUsersIndicator";
 import { Button } from "../ui/button";
@@ -27,7 +29,16 @@ export default function SpacePageHeader() {
         </div>
         <div className="flex-grow-0 flex flex-row justify-center items-center">
           <SpaceUsersIndicator />
-          <Button className="ml-2" variant="outline">
+          <Button
+            className="ml-2"
+            variant="outline"
+            onClick={() => {
+              prompt(
+                "공유",
+                `아래 주소를 공유해주세요.\n\n${window.location.href}`,
+              );
+            }}
+          >
             공유
           </Button>
         </div>

--- a/packages/frontend/src/components/space/SpacePageHeader.tsx
+++ b/packages/frontend/src/components/space/SpacePageHeader.tsx
@@ -33,9 +33,16 @@ export default function SpacePageHeader() {
             className="ml-2"
             variant="outline"
             onClick={() => {
-              prompt(
-                "공유",
-                `아래 주소를 공유해주세요.\n\n${window.location.href}`,
+              Promise.resolve(
+                prompt(
+                  "공유",
+                  <>
+                    <p>아래 주소를 공유해주세요</p>
+                    <pre className="p-2 rounded bg-muted text-muted-foreground mt-4 select-all text-wrap">
+                      {window.location.href}
+                    </pre>
+                  </>,
+                ),
               );
             }}
           >

--- a/packages/frontend/src/components/space/SpacePageHeader.tsx
+++ b/packages/frontend/src/components/space/SpacePageHeader.tsx
@@ -1,6 +1,7 @@
 import { prompt } from "@/lib/prompt-dialog";
 
 import SpaceBreadcrumb from "../SpaceBreadcrumb";
+import SpaceShareAlertContent from "../SpaceShareAlertContent";
 import SpaceUsersIndicator from "../SpaceUsersIndicator";
 import { Button } from "../ui/button";
 
@@ -33,17 +34,7 @@ export default function SpacePageHeader() {
             className="ml-2"
             variant="outline"
             onClick={() => {
-              Promise.resolve(
-                prompt(
-                  "공유",
-                  <>
-                    <p>아래 주소를 공유해주세요</p>
-                    <pre className="p-2 rounded bg-muted text-muted-foreground mt-4 select-all text-wrap">
-                      {window.location.href}
-                    </pre>
-                  </>,
-                ),
-              );
+              Promise.resolve(prompt("공유", <SpaceShareAlertContent />));
             }}
           >
             공유

--- a/packages/frontend/src/components/space/context-menu/SpaceContextMenuWrapper.tsx
+++ b/packages/frontend/src/components/space/context-menu/SpaceContextMenuWrapper.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
+import { prompt } from "@/lib/prompt-dialog";
 
 import CustomContextMenu from "./CustomContextMenu";
 import {
@@ -34,8 +35,15 @@ export default function SpaceContextMenuWrapper({
       return [
         {
           label: `${nodeTypeConfig[selectedNode.type]}명 편집`,
-          action: () => {
-            const nodeNewName = window.prompt("수정할 이름을 입력해주세요.");
+          action: async () => {
+            const { nodeNewName } = await prompt(
+              `${nodeTypeConfig[selectedNode.type]}명 편집`,
+              "수정할 이름을 입력해주세요.",
+              {
+                name: "nodeNewName",
+                label: "이름",
+              },
+            );
             if (!nodeNewName) return;
             onNodeUpdate(selectedNode.id, { name: nodeNewName });
             clearSelection();

--- a/packages/frontend/src/lib/prompt-dialog.tsx
+++ b/packages/frontend/src/lib/prompt-dialog.tsx
@@ -1,4 +1,9 @@
-import { FormEventHandler, ReactNode, useSyncExternalStore } from "react";
+import {
+  FormEventHandler,
+  ReactNode,
+  isValidElement,
+  useSyncExternalStore,
+} from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -94,7 +99,9 @@ export function PromptDialogPortal() {
         <DialogHeader>
           {data?.title && <DialogTitle>{data?.title}</DialogTitle>}
           {data?.description && (
-            <DialogDescription>{data.description}</DialogDescription>
+            <DialogDescription asChild={isValidElement(data.description)}>
+              {data.description}
+            </DialogDescription>
           )}
         </DialogHeader>
         {Boolean(data?.fields?.length) && (

--- a/packages/frontend/src/lib/prompt-dialog.tsx
+++ b/packages/frontend/src/lib/prompt-dialog.tsx
@@ -1,0 +1,131 @@
+import { FormEventHandler, ReactNode, useSyncExternalStore } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type PromptField<N extends string> = {
+  label: string;
+  name: N;
+  type?: string;
+  placeholder?: string;
+  defaultValue?: string;
+};
+
+const subscribers = new Set<() => void>();
+
+let promptContents: {
+  open: boolean;
+  title?: ReactNode;
+  description?: ReactNode;
+  fields?: PromptField<string>[];
+  onSubmit?: (data: Record<string, string>) => void;
+  onCancel?: () => void;
+} = {
+  open: false,
+};
+
+function setPrompt(update: Omit<typeof promptContents, "open">) {
+  promptContents = { ...update, open: true };
+  subscribers.forEach((fn) => fn());
+}
+function closePrompt() {
+  promptContents = { ...promptContents, open: false };
+  subscribers.forEach((fn) => fn());
+}
+
+export async function prompt<NS extends string>(
+  title: ReactNode | undefined,
+  description: ReactNode | undefined,
+  ...fields: PromptField<NS>[]
+) {
+  return new Promise<Record<NS, string>>((resolve, reject) => {
+    setPrompt({
+      title,
+      description,
+      fields,
+      onSubmit: resolve,
+      onCancel: reject,
+    });
+  });
+}
+
+export function PromptDialogPortal() {
+  const getSnapshot = () => promptContents;
+
+  const data = useSyncExternalStore((onStoreChange) => {
+    subscribers.add(onStoreChange);
+    return () => {
+      subscribers.delete(onStoreChange);
+    };
+  }, getSnapshot);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const data: Record<string, string> = {};
+    formData.forEach((value, key) => {
+      data[key] = value.toString();
+    });
+
+    promptContents.onSubmit?.(data);
+    closePrompt();
+  };
+
+  return (
+    <Dialog
+      open={data.open}
+      onOpenChange={(open) => {
+        if (!open) {
+          promptContents.onCancel?.();
+          closePrompt();
+        }
+      }}
+    >
+      <DialogContent aria-describedby={undefined}>
+        <DialogHeader>
+          {data?.title && <DialogTitle>{data?.title}</DialogTitle>}
+          {data?.description && (
+            <DialogDescription>{data.description}</DialogDescription>
+          )}
+        </DialogHeader>
+        {Boolean(data?.fields?.length) && (
+          <form onSubmit={handleSubmit}>
+            <div className="grid gap-4 py-4">
+              {data.fields?.map(
+                ({ label, name, placeholder, type, defaultValue }) => (
+                  <div
+                    key={name}
+                    className="grid grid-cols-4 items-center gap-4"
+                  >
+                    <Label htmlFor={name} className="text-right">
+                      {label}
+                    </Label>
+                    <Input
+                      name={name}
+                      className="col-span-3"
+                      placeholder={placeholder}
+                      type={type}
+                      defaultValue={defaultValue}
+                    />
+                  </div>
+                ),
+              )}
+            </div>
+            <DialogFooter>
+              <Button type="submit">확인</Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

window.prompt로 다뤄지던 기능을 자체적인 Dialog로 구현했어요

## ✅ 작업 내용

- `prompt` 모듈을 구현해서, 자체적인 Dialog를 기존 prompt와 유사한 방법으로 사용할 수 있게 했어요.

## 🏷️ 관련 이슈
- closes #53 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

https://github.com/user-attachments/assets/f4d629ad-22df-477c-ae44-e16ef0817429

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

다음과 같이 사용할 수 있도록 해주었어요. **async 함수라는 게 중요합니다.**

```ts
const { name } = await prompt("제목 (null 가능)", "설명 (null 가능)", {
        label: "제목",
        name: "name",
        placeholder: "제목을 입력하세요",
      }, { /* ...여러 폼 같이 넣는 것도 됩니다... ...반환 값의 경우 타입 지원도 됩니다... */ });
```