### PR TITLE
space connection error가 route가 바뀌어도 유지되던 문제 수정

### DIFF
--- a/packages/frontend/src/hooks/yjs/useYjsConnection.tsx
+++ b/packages/frontend/src/hooks/yjs/useYjsConnection.tsx
@@ -8,7 +8,7 @@ import { generateUserColor } from "@/lib/utils";
 export default function useYjsConnection(docName: string) {
   const [status, setStatus] = useState<
     "connecting" | "connected" | "disconnected"
-  >("connecting");
+  >("disconnected");
   const [error, setError] = useState<Error>();
   const [yDoc, setYDoc] = useState<Y.Doc>();
   const [yProvider, setYProvider] = useState<Y.AbstractConnector>();
@@ -52,6 +52,8 @@ export default function useYjsConnection(docName: string) {
       }
       setYDoc(undefined);
       setYProvider(undefined);
+      setError(undefined);
+      setStatus("disconnected");
     };
   }, [docName]);
 


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

space connection error가 route가 바뀌어도 유지되던 문제 수정

## ✅ 작업 내용
- 이전 space route에서 발생한 connection error가 유지되던 문제를 수정했습니다.
- 에러가 난 페이지에서 뒤로가기를 하여도, error가 초기화되지 않아 새로운 스페이스를 표시할 수 없었던 문제를 해결했어요.

## 🏷️ 관련 이슈
- 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.


https://github.com/user-attachments/assets/16ba0ef7-e29d-4f13-af68-32f96cb7ca11

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)