### PR TITLE
이미 연결된 노드 사이 edge 중복 생성 방지

### DIFF
--- a/packages/frontend/src/hooks/useYjsSpace.tsx
+++ b/packages/frontend/src/hooks/useYjsSpace.tsx
@@ -62,7 +62,22 @@ export default function useYjsSpace() {
       return;
     }
 
+    const edges = Array.from(yEdges.entries()).map(([id, edge]) => ({
+      id,
+      ...edge,
+    }));
+
+    const isSameEdgeExist = edges.some(
+      (edge) =>
+        (edge.from === toNodeId && edge.to === fromNodeId) ||
+        (edge.from === fromNodeId && edge.to === toNodeId),
+    );
+
+    if (isSameEdgeExist) return;
+
     const edgeId = generateUniqueId();
+
+    if (isSameEdgeExist) return;
 
     yDoc.transact(() => {
       yEdges.set(edgeId, {


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.
이미 edge가 있음에도 새로운 edge가 중복으로 생기는 버그를 해결했어요.

## ✅ 작업 내용
- edge 중복 생성 방지
- 컨텍스트 메뉴를 통해 edge 삭제 바로 반영되지 않았던 버그 수정

## 🏷️ 관련 이슈
- #61 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.
![화면 기록 2024-11-28 오후 8 46 52](https://github.com/user-attachments/assets/6fe7d541-b2ec-4d50-9fed-e9a14efc0b26)


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)