### PR TITLE
웹소켓 연결이 https에서도 동작할 수 있도록 수정

### DIFF
--- a/packages/frontend/src/api/constants.ts
+++ b/packages/frontend/src/api/constants.ts
@@ -5,3 +5,5 @@ export const API_V1_URL = import.meta.env.DEV
 export const API_V2_URL = import.meta.env.DEV
   ? "http://localhost/api/v2"
   : "/api/v2";
+
+export const WS_URL = import.meta.env.DEV ? "ws://localhost/ws" : "/ws";

--- a/packages/frontend/src/components/note/Editor.tsx
+++ b/packages/frontend/src/components/note/Editor.tsx
@@ -4,6 +4,7 @@ import { Milkdown, MilkdownProvider } from "@milkdown/react";
 import "@milkdown/theme-nord/style.css";
 import { ProsemirrorAdapterProvider } from "@prosemirror-adapter/react";
 
+import { WS_URL } from "@/api/constants";
 import useMilkdownCollab from "@/hooks/useMilkdownCollab";
 import useMilkdownEditor from "@/hooks/useMilkdownEditor";
 
@@ -19,7 +20,7 @@ function MilkdownEditor() {
 
   useMilkdownCollab({
     editor: loading ? null : get() || null,
-    websocketUrl: `ws://${import.meta.env.DEV ? "localhost" : "www.honeyflow.life"}/ws/note`,
+    websocketUrl: `${WS_URL}/note`,
     roomName: noteId || "",
   });
   return <Milkdown />;

--- a/packages/frontend/src/hooks/yjs/useYjsConnection.tsx
+++ b/packages/frontend/src/hooks/yjs/useYjsConnection.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { WebsocketProvider } from "y-websocket";
 import * as Y from "yjs";
 
+import { WS_URL } from "@/api/constants";
 import { generateUserColor } from "@/lib/utils";
 
 export default function useYjsConnection(docName: string) {
@@ -17,11 +18,7 @@ export default function useYjsConnection(docName: string) {
     setStatus("connecting");
 
     const doc = new Y.Doc();
-    const provider = new WebsocketProvider(
-      `ws://${import.meta.env.DEV ? "localhost" : "www.honeyflow.life"}/ws/space`,
-      docName,
-      doc,
-    );
+    const provider = new WebsocketProvider(`${WS_URL}/space`, docName, doc);
 
     setYDoc(doc);
     setYProvider(provider);


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

기존엔 `ws://...`로 명시해놓았어서, https 환경에서는 웹소켓 서버에 접속할 수 없었어요.


## ✅ 작업 내용

- API 요청과 마찬가지로, 현재 origin에 맞게 동작하도록 수정하였어요.
- 하드코딩되어 있는 웹소켓 URL을 수정했어요

## 🏷️ 관련 이슈
- 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)