### PR TITLE
노드 타입 별 스타일 적용

### DIFF
--- a/packages/frontend/src/components/Edge.tsx
+++ b/packages/frontend/src/components/Edge.tsx
@@ -53,7 +53,7 @@ export default function Edge({
     >
       <Line
         points={points}
-        stroke={"#FFCC00"}
+        stroke={"#D4AD2F"}
         strokeWidth={isHovered ? 5 : 3}
         opacity={isHovered ? 1 : 0.8}
         {...rest}

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -36,16 +36,25 @@ export default function Node({
 type NodeCircleProps = {
   radius: number;
   fill: string;
+  stroke?: string;
   shadowColor?: string;
 };
 
 Node.Circle = function NodeCircle({
   radius,
   fill,
+  stroke,
   shadowColor = "#F9D46B",
 }: NodeCircleProps) {
   return (
-    <Circle x={0} y={0} radius={radius} fill={fill} shadowColor={shadowColor} />
+    <Circle
+      x={0}
+      y={0}
+      radius={radius}
+      fill={fill}
+      stroke={stroke}
+      shadowColor={shadowColor}
+    />
   );
 };
 
@@ -97,7 +106,7 @@ export function HeadNode({ id, name, ...rest }: HeadNodeProps) {
   const radius = 64;
   return (
     <Node id={id} x={0} y={0} draggable {...rest}>
-      <Node.Circle radius={radius} fill="#FFCC00" />
+      <Node.Circle radius={radius} fill="#FFD000" />
       <Node.Text
         width={radius * 2}
         fontSize={16}
@@ -128,7 +137,7 @@ export function NoteNode({ id, x, y, name, src, ...rest }: NoteNodeProps) {
       onClick={() => navigate(`/note/${src}`)}
       {...rest}
     >
-      <Node.Circle radius={radius} fill="#FFF2CB" />
+      <Node.Circle radius={radius} fill="#FAF9F7" stroke="#DED8D3" />
       <Node.Text fontSize={16} content={name} />
     </Node>
   );
@@ -160,7 +169,7 @@ export function SubspaceNode({
       onClick={() => navigate(`/space/${src}`)}
       {...rest}
     >
-      <Node.Circle radius={64} fill="#FFF2CB" />
+      <Node.Circle radius={64} fill="#FFF4BB" stroke="#F9D46B" />
       <Node.Text fontSize={16} fontStyle="700" content={name} />
     </Node>
   );


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

노드 타입 별로 구분이 가능하도록 스타일을 적용하였습니다.

## ✅ 작업 내용
- node circle 컴포넌트에 optional로 stroke prop 추가
- head, note, subspace 컴포넌트에 fill, stroke 적용

## 🏷️ 관련 이슈
- closes #190 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

![Screen Recording 2024-12-02 at 4 19 42 PM](https://github.com/user-attachments/assets/fcacea60-3d2d-43bb-b168-fe146f875e56)


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)
- 간단한 수정 작업이라 이상한 점이 없는지만 확인해주시면 될 것 같습니다!