### PR TITLE
노드 위 우클릭시 이동모드 자동 활성화되는 오류 수정

### DIFF
--- a/packages/frontend/src/hooks/useMoveNode.ts
+++ b/packages/frontend/src/hooks/useMoveNode.ts
@@ -64,6 +64,11 @@ export default function useMoveNode({ nodes, spaceActions }: useMoveNodeProps) {
 
   // onMouseDown, onTouchStart
   const startHold = (node: Node, e: KonvaInteractionEvent) => {
+    // 우클릭으로 이벤트가 발생했을 경우 이동모드 활성화 방지
+    if (e.evt.button === 2) {
+      return;
+    }
+
     setMoveState((prev) => ({
       ...prev,
       isHolding: true,


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

노드 위 우클릭시 이동모드 자동 활성화되는 오류를 수정했어요. (Mac 환경에서만 발생하는 오류였어요)

## ✅ 작업 내용
- 홀드 타이머 함수에서 우클릭 분기처리. 

## 🏷️ 관련 이슈
- #62 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.
  
![이동모드비활성화](https://github.com/user-attachments/assets/abc00871-a0e3-494e-b707-b51143fe273a)


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)
