### PR TITLE
모바일 환경에서 더보기 버튼을 통한 노드.간선 편집

### DIFF
--- a/packages/frontend/src/components/Edge.tsx
+++ b/packages/frontend/src/components/Edge.tsx
@@ -1,10 +1,62 @@
 import { useEffect, useState } from "react";
-import { Group, Line } from "react-konva";
+import { Circle, Group, Line, Text } from "react-konva";
 
 import Konva from "konva";
+import { KonvaEventObject, Node, NodeConfig } from "konva/lib/Node";
 import type { Edge } from "shared/types";
 
 type EdgeProps = Edge & Konva.LineConfig;
+
+const BUTTON_RADIUS = 12;
+
+type EdgeEditButtonProps = {
+  points: number[];
+  onTap?:
+    | ((evt: KonvaEventObject<PointerEvent, Node<NodeConfig>>) => void)
+    | undefined;
+};
+
+function EdgeEditButton({ points, onTap }: EdgeEditButtonProps) {
+  const [isTouch, setIsTouch] = useState(false);
+
+  useEffect(() => {
+    setIsTouch("ontouchstart" in window || navigator.maxTouchPoints > 0);
+  }, []);
+
+  if (!isTouch || points.length < 4) return null;
+
+  const handleTap = (e: KonvaEventObject<MouseEvent | TouchEvent>) => {
+    if (onTap) {
+      const { target } = e;
+      console.log(target);
+    }
+  };
+
+  const middleX = (points[0] + points[2]) / 2;
+  const middleY = (points[1] + points[3]) / 2;
+
+  return (
+    <Group x={middleX} y={middleY} onTap={handleTap}>
+      <Circle
+        radius={BUTTON_RADIUS}
+        fill="#FAF9F7"
+        stroke="#FFFFFF"
+        strokeWidth={2}
+      />
+      <Text
+        fontSize={16}
+        fill="#787878"
+        text="×"
+        align="center"
+        verticalAlign="middle"
+        width={BUTTON_RADIUS * 2}
+        height={BUTTON_RADIUS * 2}
+        offsetX={BUTTON_RADIUS}
+        offsetY={BUTTON_RADIUS - 1}
+      />
+    </Group>
+  );
+}
 
 function calculateOffsets(
   from: { x: number; y: number },
@@ -66,6 +118,7 @@ export default function Edge({
         name="edge"
         id={id}
       />
+      <EdgeEditButton points={points} />
     </Group>
   );
 }

--- a/packages/frontend/src/components/Edge.tsx
+++ b/packages/frontend/src/components/Edge.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Circle, Group, Line, Text } from "react-konva";
 
 import Konva from "konva";
-import { KonvaEventObject, Node, NodeConfig } from "konva/lib/Node";
+import { KonvaEventObject } from "konva/lib/Node";
 import type { Edge } from "shared/types";
 
 type EdgeProps = Edge & Konva.LineConfig;
@@ -11,9 +11,7 @@ const BUTTON_RADIUS = 12;
 
 type EdgeEditButtonProps = {
   points: number[];
-  onTap?:
-    | ((evt: KonvaEventObject<PointerEvent, Node<NodeConfig>>) => void)
-    | undefined;
+  onTap: (edgeId: string) => void;
 };
 
 function EdgeEditButton({ points, onTap }: EdgeEditButtonProps) {
@@ -26,10 +24,19 @@ function EdgeEditButton({ points, onTap }: EdgeEditButtonProps) {
   if (!isTouch || points.length < 4) return null;
 
   const handleTap = (e: KonvaEventObject<MouseEvent | TouchEvent>) => {
-    if (onTap) {
-      const { target } = e;
-      console.log(target);
-    }
+    const targetGroup = e.target
+      .findAncestor("Group")
+      .findAncestor("Group") as Konva.Group;
+
+    if (!targetGroup) return;
+
+    const targetEdge = targetGroup.children.find(
+      (konvaNode) => konvaNode.attrs.name === "edge",
+    );
+
+    if (!targetEdge) return;
+
+    onTap(targetEdge.attrs.id);
   };
 
   const middleX = (points[0] + points[2]) / 2;
@@ -78,6 +85,7 @@ export default function Edge({
   to,
   id,
   onContextMenu,
+  onDelete,
   ...rest
 }: EdgeProps) {
   const [points, setPoints] = useState<number[]>([]);
@@ -118,7 +126,7 @@ export default function Edge({
         name="edge"
         id={id}
       />
-      <EdgeEditButton points={points} />
+      <EdgeEditButton points={points} onTap={onDelete} />
     </Group>
   );
 }

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -11,6 +11,7 @@ import {
 import { Vector2d } from "konva/lib/types";
 
 const RADIUS = 64;
+const MORE_BUTTON_RADIUS = 12;
 
 type NodeProps = {
   id: string;
@@ -126,11 +127,17 @@ Node.MoreButton = function NodeMoreButton({ content }: NodeMoreButtonProps) {
     e.cancelBubble = true;
 
     const parentNode = e.target.findAncestor("Group").findAncestor("Group");
+
     if (!parentNode) return;
+
+    const absolutePosition = parentNode.getAbsolutePosition();
 
     const contextMenuEvent = new MouseEvent("contextmenu", {
       button: 2,
       buttons: 2,
+      clientX: absolutePosition.x,
+      clientY: absolutePosition.y,
+      bubbles: true,
     });
 
     parentNode.fire("contextmenu", {
@@ -144,7 +151,7 @@ Node.MoreButton = function NodeMoreButton({ content }: NodeMoreButtonProps) {
       <Circle
         x={0}
         y={0}
-        radius={12}
+        radius={MORE_BUTTON_RADIUS}
         fill="#FFFFFF"
         stroke="#DED8D3"
         strokeWidth={1.5}
@@ -156,10 +163,10 @@ Node.MoreButton = function NodeMoreButton({ content }: NodeMoreButtonProps) {
         text={content}
         align="center"
         verticalAlign="middle"
-        width={24}
-        height={24}
-        offsetX={12}
-        offsetY={12}
+        width={MORE_BUTTON_RADIUS * 2}
+        height={MORE_BUTTON_RADIUS * 2}
+        offsetX={MORE_BUTTON_RADIUS}
+        offsetY={MORE_BUTTON_RADIUS}
       />
     </Group>
   );

--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useRef, useState } from "react";
-import { Circle, Group, KonvaNodeEvents, Text } from "react-konva";
+import { Circle, Group, KonvaNodeEvents, Shape, Text } from "react-konva";
 import { useNavigate } from "react-router-dom";
 
 import Konva from "konva";
@@ -99,6 +99,29 @@ Node.Text = function NodeText({
   );
 };
 
+Node.MoreButton = function NodeMoreButton({ onTap }: { onTap: () => void }) {
+  const [isTouch, setIsTouch] = useState(false);
+
+  useEffect(() => {
+    setIsTouch("ontouchstart" in window || navigator.maxTouchPoints > 0);
+  }, []);
+
+  if (!isTouch) return null;
+
+  return (
+    <Group onTap={onTap}>
+      <Circle
+        x={45}
+        y={-45}
+        radius={12}
+        fill="#FFFFFF"
+        stroke="#FFB800"
+        strokeWidth={1}
+      />
+    </Group>
+  );
+};
+
 export type HeadNodeProps = {
   id: string;
   name: string;
@@ -143,6 +166,7 @@ export function NoteNode({ id, x, y, name, src, ...rest }: NoteNodeProps) {
     >
       <Node.Circle radius={RADIUS} fill="#FAF9F7" stroke="#DED8D3" />
       <Node.Text width={RADIUS * 2} fontSize={16} content={name} />
+      <Node.MoreButton onTap={() => console.log("터치!")} />
     </Node>
   );
 }
@@ -174,7 +198,12 @@ export function SubspaceNode({
       {...rest}
     >
       <Node.Circle radius={RADIUS} fill="#FFF4BB" stroke="#F9D46B" />
-      <Node.Text width={RADIUS * 2} fontSize={16} fontStyle="700" content={name} />
+      <Node.Text
+        width={RADIUS * 2}
+        fontSize={16}
+        fontStyle="700"
+        content={name}
+      />
     </Node>
   );
 }

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -301,6 +301,7 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
         to={edge.to}
         nodes={nodes}
         onContextMenu={handleContextMenu}
+        onDelete={deleteEdge}
       />
     ));
 

--- a/packages/frontend/src/components/space/SpaceView.tsx
+++ b/packages/frontend/src/components/space/SpaceView.tsx
@@ -146,7 +146,7 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
     };
   }, [autofitTo]);
 
-  const handleContextMenu = (e: KonvaEventObject<MouseEvent>) => {
+  const handleContextMenu = (e: KonvaEventObject<MouseEvent | Event>) => {
     clearSelection();
 
     const { target } = e;
@@ -159,7 +159,9 @@ export default function SpaceView({ spaceId, autofitTo }: SpaceViewProps) {
       return;
     }
 
-    const group = target.findAncestor("Group");
+    // Mobile 환경에서는 group을 대상으로 임의로 이벤트 발생시킴
+    const group =
+      target instanceof Konva.Group ? target : target.findAncestor("Group");
 
     const nodeId = group?.attrs?.id as string | undefined;
 


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

터치 디바이스로 접속 시에 컨텍스트 메뉴를 띄울 수 있는 더보기 버튼을 구현했어요.
간선을 삭제할 수 있는 별도의 버튼을 구현했어요.


## ✅ 작업 내용
- 터치 디바이스 기기 여부 확인
- 더보기 버튼 클릭 시 컨텍스트 메뉴 표시
- 간선 중간에 삭제 버튼 표시

## 🏷️ 관련 이슈
- #198 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.
  
![모바일우클릭](https://github.com/user-attachments/assets/c893136d-31b2-40d2-b250-bdecd42cba7d)
![모바일간선](https://github.com/user-attachments/assets/b82f70df-6639-409d-bddc-c744643058d0)



## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)

눈물을 흘리며 ios 업데이트 후 제 아이폰 환경에서도 테스트를 마쳤습니다!
(도커 빌드도 확인 완료했습니다)

구현 아이디어가 거의 같아서 간선 조작에 대한 작업도 살짝 추가했습니다 😅