### PR TITLE
더 많은 브라우저에서 WebSocket 연결 문제가 없도록 수정

### DIFF
--- a/packages/frontend/src/lib/polyfill-relative-urls-websocket.ts
+++ b/packages/frontend/src/lib/polyfill-relative-urls-websocket.ts
@@ -1,0 +1,17 @@
+// Monkey Patch로 WebSocket 생성자를 오버라이드
+const OriginalWebSocket = window.WebSocket;
+
+// @ts-expect-error Monkey Patch
+window.WebSocket = function WebSocket(url, protocols) {
+  const parsedUrl = new URL(url, window.location.href);
+
+  if (parsedUrl.protocol === "http:") {
+    parsedUrl.protocol = "ws:";
+  } else if (parsedUrl.protocol === "https:") {
+    parsedUrl.protocol = "wss:";
+  }
+
+  return new OriginalWebSocket(parsedUrl.href, protocols);
+};
+
+window.WebSocket.prototype = OriginalWebSocket.prototype;

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
+import "@/lib/polyfill-relative-urls-websocket.ts";
+
 import App from "./App.tsx";
 import "./index.css";
 


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

구버전 브라우저 환경에서도 WebSocket 연결 문제가 없도록 수정했습니다.

## ✅ 작업 내용

- 과거 버전에서도 http/https, 그리고 상대 url을 웹소켓 주소로 제대로 해석할 수 있도록 polyfill을 작성했습니다.
- polyfill은 단순히 monkey patch로 해주었습니다.

## 🏷️ 관련 이슈

- closes #206 

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.

문제가 나타날 수 있는 환경을 위해 `Firefox 121` 버전을 설치 후 테스트해보았습니다.

(좌측: 기존, 우측: 개선)

<img width="1512" alt="스크린샷 2024-12-03 오후 10 30 01" src="https://github.com/user-attachments/assets/5b794d55-5aa1-4e95-affe-b4a062a64494">

## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)