### PR TITLE
모바일 노드 진입 시 탭 이벤트 추가

### DIFF
--- a/packages/frontend/src/components/Node.tsx
+++ b/packages/frontend/src/components/Node.tsx
@@ -220,6 +220,9 @@ export function NoteNode({
           navigate(`/note/${src}`);
         }
       }}
+      onTap={() => {
+        navigate(`/note/${src}`);
+      }}
       onContextMenu={onContextMenu}
       {...rest}
     >
@@ -255,6 +258,7 @@ export function SubspaceNode({
       x={x}
       y={y}
       onClick={() => navigate(`/space/${src}`)}
+      onTap={() => navigate(`/space/${src}`)}
       onContextMenu={onContextMenu}
       {...rest}
     >


### PR DESCRIPTION
## ✏️ 한 줄 설명
> 이 PR의 주요 변경 사항이나 구현된 내용을 간략히 설명해 주세요.

터치 디바이스 환경에서 노트.서브스페이스 진입 가능하도록 수정


## ✅ 작업 내용
- 터치 디바이스 환경에서 노트.서브스페이스 진입 시 tap이벤트로도 처리하였습니다.

## 📸 스크린샷/영상
> 이번 PR에서 변경되거나 추가된 뷰가 있는 경우 이미지나 동작 영상을 첨부해 주세요.
![모바일진입](https://github.com/user-attachments/assets/fe787a5f-b8aa-4f35-b94d-dbfcb1711443)


## 📌 리뷰 진행 시 참고 사항
> 리뷰 코멘트 작성 시 특정 사실에 대해 짚는 것이 아니라 코드에 대한 의견을 제안할 경우, 강도를 함께 제시해주세요! (1점: 가볍게 참고해봐도 좋을듯 ↔ 5점: 꼭 바꾸는 게 좋을 것 같음!)
